### PR TITLE
Organize RPL Predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,15 @@ dependencies = [
  "rpl_macros",
  "rpl_match",
  "rpl_mir",
+ "rpl_predicates",
+]
+
+[[package]]
+name = "rpl_predicates"
+version = "0.1.0"
+dependencies = [
+ "rpl_match",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rpl_pat_syntax = { path = "./crates/rpl_pat_syntax" }
 rpl_patterns = { path = "./crates/rpl_patterns" }
 rpl_utils = { path = "./crates/rpl_utils" }
 rpl_parser = { path = "./crates/rpl_parser" }
+rpl_predicates = { path = "./crates/rpl_predicates" }
 rustc_tools_util = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The toolchain of RPL, which is a custom configuration of Rust compiler, enables 
 
 ## RPL Language Reference
 
-See [this website](https://rpl-toolchain.github.io/RPL/) for the RPL book (Work in progress).
+See [this website](https://rpl-toolchain.github.io/rpl-book/) for the RPL book (Work in progress).
 
 ## Getting Help
 

--- a/crates/rpl_context/src/context.rs
+++ b/crates/rpl_context/src/context.rs
@@ -146,7 +146,7 @@ impl<'pcx> PatCtxt<'pcx> {
     pub fn mk_fn(self, path_with_args: pat::PathWithArgs<'pcx>) -> Ty<'pcx> {
         self.mk_path_ty(path_with_args)
     }
-    pub fn mk_var_ty(self, ty_var: pat::TyVar) -> Ty<'pcx> {
+    pub fn mk_var_ty(self, ty_var: pat::TyVar<'pcx>) -> Ty<'pcx> {
         self.mk_ty(TyKind::TyVar(ty_var))
     }
     pub fn mk_var_const(self, const_var: pat::ConstVar<'pcx>) -> Const<'pcx> {

--- a/crates/rpl_context/src/pat/mod.rs
+++ b/crates/rpl_context/src/pat/mod.rs
@@ -1,3 +1,4 @@
+use either::Either;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_index::IndexVec;
 use rustc_span::Symbol;
@@ -15,7 +16,7 @@ pub use ty::*;
 
 #[derive(Default)]
 pub struct MetaVars<'pcx> {
-    pub ty_vars: IndexVec<TyVarIdx, TyVar>,
+    pub ty_vars: IndexVec<TyVarIdx, TyVar<'pcx>>,
     pub place_vars: IndexVec<PlaceVarIdx, PlaceVar<'pcx>>,
     pub const_vars: IndexVec<ConstVarIdx, ConstVar<'pcx>>,
 }
@@ -29,7 +30,7 @@ pub struct Pattern<'pcx> {
 }
 
 impl<'pcx> MetaVars<'pcx> {
-    pub fn new_ty_var(&mut self, pred: Option<TyPred>) -> TyVar {
+    pub fn new_ty_var(&mut self, pred: &'pcx [&'pcx [Either<TyPred, TyPred>]]) -> TyVar<'pcx> {
         let idx = self.ty_vars.next_index();
         let ty_var = TyVar { idx, pred };
         self.ty_vars.push(ty_var);

--- a/crates/rpl_context/src/pat/pretty.rs
+++ b/crates/rpl_context/src/pat/pretty.rs
@@ -148,13 +148,13 @@ impl fmt::Debug for IntValue {
     }
 }
 
-impl fmt::Debug for TyVar {
+impl fmt::Debug for TyVar<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.idx.fmt(f)
     }
 }
 
-impl fmt::Display for TyVar {
+impl fmt::Display for TyVar<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self, f)
     }

--- a/crates/rpl_context/src/pat/ty.rs
+++ b/crates/rpl_context/src/pat/ty.rs
@@ -7,6 +7,8 @@ use rustc_middle::mir;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Symbol;
 
+use either::Either;
+
 use crate::PatCtxt;
 use crate::cvt_prim_ty::CvtPrimTy;
 
@@ -56,7 +58,7 @@ pub enum RegionKind {
 
 #[derive(Clone, Copy)]
 pub enum TyKind<'pcx> {
-    TyVar(TyVar),
+    TyVar(TyVar<'pcx>),
     AdtPat(Symbol),
     Array(Ty<'pcx>, Const<'pcx>),
     Slice(Ty<'pcx>),
@@ -302,9 +304,9 @@ impl<'pcx> From<ConstVar<'pcx>> for Const<'pcx> {
 }
 
 #[derive(Clone, Copy)]
-pub struct TyVar {
+pub struct TyVar<'pcx> {
     pub idx: TyVarIdx,
-    pub pred: Option<TyPred>,
+    pub pred: &'pcx [&'pcx [Either<TyPred, TyPred>]],
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rpl_match/src/lib.rs
+++ b/crates/rpl_match/src/lib.rs
@@ -12,6 +12,7 @@ extern crate rustc_middle;
 extern crate rustc_span;
 #[macro_use]
 extern crate tracing;
+extern crate either;
 
 mod adt;
 mod counted;

--- a/crates/rpl_pat_expand/src/tests.rs
+++ b/crates/rpl_pat_expand/src/tests.rs
@@ -69,7 +69,28 @@ fn test_ty_var() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
+                #[allow(non_snake_case)]
+                let T_ty = pcx.mk_var_ty(T_ty_var);
+            }
+        }
+    );
+}
+
+#[test]
+fn test_ty_var_preds() {
+    mir_test_case!(
+        #[meta($T:ty where a || b)]
+        pat! {
+        } => {
+            meta! {
+                #[allow(non_snake_case)]
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[
+                    &[
+                        either::Either::Left(a),
+                        either::Either::Left(b),
+                    ],
+                ]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
             }
@@ -89,7 +110,7 @@ fn test_const_var() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
                 #[allow(non_snake_case)]
@@ -154,7 +175,7 @@ fn test_place_var() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
                 #[allow(non_snake_case)]
@@ -193,7 +214,7 @@ fn test_coercion() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
             }
@@ -241,7 +262,7 @@ fn test_coercion() {
 #[test]
 fn test_cve_2020_25016() {
     mir_test_case!(
-        #[meta( #[export(ty_var)] $T:ty = is_all_safe_trait)]
+        #[meta( #[export(ty_var)] $T:ty where is_all_safe_trait)]
         pat! {
             type SliceT = [$T];
             type RefSliceT = &SliceT;
@@ -264,7 +285,11 @@ fn test_cve_2020_25016() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(Some(is_all_safe_trait));
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[
+                    &[
+                        either::Either::Left(is_all_safe_trait),
+                    ],
+                ]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
                 ty_var = T_ty_var;
@@ -380,7 +405,7 @@ fn test_cve_2020_35877_unchecked_offset_const() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
                 #[allow(non_snake_case)]
@@ -536,12 +561,12 @@ fn test_cve_2020_35892_revised() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
 
                 #[allow(non_snake_case)]
-                let SlabT_ty_var = pattern_fn.meta.new_ty_var(None);
+                let SlabT_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let SlabT_ty = pcx.mk_var_ty(SlabT_ty_var);
             }
@@ -882,11 +907,11 @@ fn test_cve_2020_35892() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
                 #[allow(non_snake_case)]
-                let SlabT_ty_var = pattern_fn.meta.new_ty_var(None);
+                let SlabT_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let SlabT_ty = pcx.mk_var_ty(SlabT_ty_var);
             }
@@ -1078,15 +1103,15 @@ fn test_cve_2018_21000() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T1_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T1_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T1_ty = pcx.mk_var_ty(T1_ty_var);
                 #[allow(non_snake_case)]
-                let T2_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T2_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T2_ty = pcx.mk_var_ty(T2_ty_var);
                 #[allow(non_snake_case)]
-                let T3_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T3_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T3_ty = pcx.mk_var_ty(T3_ty_var);
             }
@@ -1224,7 +1249,7 @@ fn test_cve_2020_35881_const() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T1_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T1_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T1_ty = pcx.mk_var_ty(T1_ty_var);
             }
@@ -1342,7 +1367,7 @@ fn test_cve_2020_35881_mut() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T1_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T1_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T1_ty = pcx.mk_var_ty(T1_ty_var);
             }
@@ -1497,7 +1522,7 @@ fn test_cve_2021_29941_2() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
             }
@@ -1817,7 +1842,7 @@ fn test_cve_2018_21000_inlined() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
             }
@@ -2034,7 +2059,7 @@ fn test_cve_2019_15548() {
         } => {
             meta!{
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
             }
@@ -2104,7 +2129,7 @@ fn test_cve_2019_15548_2() {
         } => {
             meta!{
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
             }
@@ -2291,7 +2316,7 @@ fn test_cve_2020_35877() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
             }
@@ -2441,7 +2466,7 @@ fn test_cve_2020_35873() {
         } => quote! {
             let ffi_call_fn = pattern.fns.new_fn_pat(::rustc_span::Symbol::intern("ffi_call"));
             #[allow(non_snake_case)]
-            let SessT_ty_var = ffi_call_fn.meta.new_ty_var(None);
+            let SessT_ty_var = ffi_call_fn.meta.new_ty_var(&[]);
             #[allow(non_snake_case)]
             let SessT_ty = pcx.mk_var_ty(SessT_ty_var );
             ffi_call_fn.set_ret_ty(pcx.primitive_types.i32);
@@ -2483,7 +2508,7 @@ fn test_cve_2020_35892_3() {
             let SlabT_adt = pattern.new_struct(::rustc_span::Symbol::intern("SlabT"));
 
             #[allow(non_snake_case)]
-            let T_ty_var = SlabT_adt.meta.new_ty_var(None);
+            let T_ty_var = SlabT_adt.meta.new_ty_var(&[]);
             #[allow(non_snake_case)]
             let T_ty = pcx.mk_var_ty(T_ty_var);
 
@@ -2495,7 +2520,7 @@ fn test_cve_2020_35892_3() {
         }
     );
     mir_test_case!(
-        #[meta($T:ty, $SlabT:ty = |_tcx, _paramse_env, ty| ty.is_adt())]
+        #[meta($T:ty, $SlabT:ty)]
         pat! {
             let $self: &mut $SlabT;
             #[export(len)]
@@ -2510,12 +2535,12 @@ fn test_cve_2020_35892_3() {
         } => {
             meta! {
                 #[allow(non_snake_case)]
-                let T_ty_var = pattern_fn.meta.new_ty_var(None);
+                let T_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let T_ty = pcx.mk_var_ty(T_ty_var);
 
                 #[allow(non_snake_case)]
-                let SlabT_ty_var = pattern_fn.meta.new_ty_var(Some(|_tcx, _paramse_env, ty| ty.is_adt()));
+                let SlabT_ty_var = pattern_fn.meta.new_ty_var(&[]);
                 #[allow(non_snake_case)]
                 let SlabT_ty = pcx.mk_var_ty(SlabT_ty_var);
             }
@@ -2595,7 +2620,7 @@ fn test_cve_2020_35892_3() {
 fn test_cve_2020_35907() {
     test_case! {
         pat! {
-            #[meta($T:ty = is_sync)]
+            #[meta($T:ty where is_sync)]
             fn $pattern(..) -> &'static $T = mir! {
                 let $result: core::result::Result<&'static $T, _> =
                     std::thread::LocalKey::<std::cell::UnsafeCell<std::task::Waker>>::try_with::<_, _>(_, _);
@@ -2605,7 +2630,11 @@ fn test_cve_2020_35907() {
         } => quote! {
             let pattern_fn = pattern.fns.new_fn_pat(::rustc_span::Symbol::intern("pattern"));
             #[allow(non_snake_case)]
-            let T_ty_var = pattern_fn.meta.new_ty_var(Some(is_sync));
+            let T_ty_var = pattern_fn.meta.new_ty_var(&[
+                &[
+                    either::Either::Left(is_sync),
+                ],
+            ]);
             #[allow(non_snake_case)]
             let T_ty = pcx.mk_var_ty(T_ty_var);
             pattern_fn.set_ret_ty(pcx.mk_ref_ty(

--- a/crates/rpl_pat_syntax/src/tests.rs
+++ b/crates/rpl_pat_syntax/src/tests.rs
@@ -228,10 +228,33 @@ fn test_meta() {
     pass!(Meta!(#[meta($T:ty)]));
     pass!(Meta!(#[meta($T:ty, $U:ty)]));
     pass!(Meta!(#[meta( #[export(ty_var)] $T:ty, )]));
-    pass!(Meta!(#[meta($T:ty = is_all_safe_trait)]));
+    pass!(Meta!(#[meta($T:ty where is_all_safe_trait)]));
+    pass!(Meta!(#[meta($T:ty where is_all_safe_trait && !is_primitive_type)]));
     pass!(Meta!(#[meta($T:ty, $p:place(alloc::vec::Vec<$T>))]));
     pass!(Meta!(#[meta($T:ty, $c:const($T))]));
-    pass!(Meta!(#[meta($T:ty, $c:const(&$T))]));
+    pass!(Meta!(#[meta($T:ty, $c:const(&$T) where (a || b) && c && e)]));
+}
+
+#[test]
+fn test_predicate_conjunction() {
+    pass!(PredicateConjunction!(a && b));
+    pass!(PredicateConjunction!((a || !b) && c));
+    pass!(PredicateConjunction!(a || b || c));
+}
+
+#[test]
+fn test_predicate_clause() {
+    pass!(PredicateClause!(a));
+    pass!(PredicateClause!(!a));
+    pass!(PredicateClause!(a || b));
+    pass!(PredicateClause!((a || b)));
+    pass!(PredicateClause!(a || b || !c));
+}
+
+#[test]
+fn test_predicate() {
+    pass!(Predicate!(!a::b));
+    pass!(Predicate!(a::b));
 }
 
 #[test]

--- a/crates/rpl_patterns/Cargo.toml
+++ b/crates/rpl_patterns/Cargo.toml
@@ -12,6 +12,7 @@ rpl_macros.workspace = true
 rpl_match.workspace = true
 rpl_mir.workspace = true
 rpl_context.workspace = true
+rpl_predicates.workspace = true
 
 [dev-dependencies]
 libc.workspace = true

--- a/crates/rpl_patterns/src/inline/alloc_unchecked.rs
+++ b/crates/rpl_patterns/src/inline/alloc_unchecked.rs
@@ -138,7 +138,7 @@ struct Pattern<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     alloc: pat::Location,
     write: pat::Location,
-    ty: pat::TyVar,
+    ty: pat::TyVar<'pcx>,
 }
 
 #[rpl_macros::pattern_def]

--- a/crates/rpl_patterns/src/inline/cve_2020_25016.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_25016.rs
@@ -6,8 +6,8 @@ use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_middle::hir::nested_filter::All;
-use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::{Span, Symbol, sym};
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::{Span, Symbol};
 
 use crate::lints::UNSOUND_SLICE_CAST;
 
@@ -121,7 +121,7 @@ fn pattern_cast(pcx: PatCtxt<'_>) -> PatternCast<'_> {
     let cast_from;
     let cast_to;
     let pattern = rpl! {
-        #[meta( #[export(ty_var)] $T:ty = is_all_safe_trait)]
+        #[meta( #[export(ty_var)] $T:ty = rpl_predicates::is_all_safe_trait)]
         fn $pattern (..) -> _ = mir! {
             #[export(cast_from)]
             let $from_slice: &[$T] = _;
@@ -154,7 +154,7 @@ fn pattern_cast_mut(pcx: PatCtxt<'_>) -> PatternCast<'_> {
     let cast_from;
     let cast_to;
     let pattern = rpl! {
-        #[meta( #[export(ty_var)] $T:ty = is_all_safe_trait)]
+        #[meta( #[export(ty_var)] $T:ty = rpl_predicates::is_all_safe_trait)]
         fn $pattern (..) -> _ = mir! {
 
             #[export(cast_from)]
@@ -180,26 +180,4 @@ fn pattern_cast_mut(pcx: PatCtxt<'_>) -> PatternCast<'_> {
         cast_from,
         cast_to,
     }
-}
-
-#[instrument(level = "debug", skip(tcx), ret)]
-fn is_all_safe_trait<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, self_ty: Ty<'tcx>) -> bool {
-    if self_ty.is_primitive() {
-        return false;
-    }
-    const EXCLUDED_DIAG_ITEMS: &[Symbol] = &[sym::Send, sym::Sync];
-    typing_env
-        .param_env
-        .caller_bounds()
-        .iter()
-        .filter_map(|clause| clause.as_trait_clause())
-        .filter(|clause| clause.self_ty().no_bound_vars().expect("Unhandled bound vars") == self_ty)
-        .map(|clause| clause.def_id())
-        .filter(|&def_id| {
-            tcx.get_diagnostic_name(def_id)
-                .is_none_or(|name| !EXCLUDED_DIAG_ITEMS.contains(&name))
-        })
-        .map(|def_id| tcx.trait_def(def_id))
-        .inspect(|trait_def| debug!(?trait_def))
-        .all(|trait_def| matches!(trait_def.safety, hir::Safety::Safe))
 }

--- a/crates/rpl_patterns/src/inline/cve_2020_25016.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_25016.rs
@@ -121,7 +121,8 @@ fn pattern_cast(pcx: PatCtxt<'_>) -> PatternCast<'_> {
     let cast_from;
     let cast_to;
     let pattern = rpl! {
-        #[meta( #[export(ty_var)] $T:ty = rpl_predicates::is_all_safe_trait)]
+        #[meta( #[export(ty_var)] $T:ty
+            where rpl_predicates::is_all_safe_trait && !rpl_predicates::is_primitive)]
         fn $pattern (..) -> _ = mir! {
             #[export(cast_from)]
             let $from_slice: &[$T] = _;
@@ -154,7 +155,8 @@ fn pattern_cast_mut(pcx: PatCtxt<'_>) -> PatternCast<'_> {
     let cast_from;
     let cast_to;
     let pattern = rpl! {
-        #[meta( #[export(ty_var)] $T:ty = rpl_predicates::is_all_safe_trait)]
+        #[meta( #[export(ty_var)] $T:ty
+            where rpl_predicates::is_all_safe_trait && !rpl_predicates::is_primitive)]
         fn $pattern (..) -> _ = mir! {
 
             #[export(cast_from)]

--- a/crates/rpl_patterns/src/inline/cve_2020_35862.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35862.rs
@@ -89,7 +89,7 @@ struct Pattern<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     vec_move: pat::Location,
     ptr_use: pat::Location,
-    ty: pat::TyVar,
+    ty: pat::TyVar<'pcx>,
 }
 
 #[rpl_macros::pattern_def]

--- a/crates/rpl_patterns/src/inline/cve_2020_35901_2.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35901_2.rs
@@ -95,7 +95,7 @@ struct PatternPin<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     mut_self: pat::Local,
     pin_new: pat::Location,
-    ty_var: pat::TyVar,
+    ty_var: pat::TyVar<'pcx>,
 }
 
 #[rpl_macros::pattern_def]
@@ -110,7 +110,7 @@ fn pattern_pin(pcx: PatCtxt<'_>) -> PatternPin<'_> {
             $field: $S,
         }
 
-        #[meta(#[export(ty_var)] $S:ty = rpl_predicates::is_not_unpin)]
+        #[meta(#[export(ty_var)] $S:ty where rpl_predicates::is_not_unpin)]
         fn $pattern(..) -> _ = mir! {
             #[export(mut_self)]
             let $self: &mut $SizedStream;
@@ -144,7 +144,7 @@ fn pattern_pin_field(pcx: PatCtxt<'_>) -> PatternPin<'_> {
             $field: $T,
         }
 
-        #[meta(#[export(ty_var)] $T:ty = rpl_predicates::is_not_unpin)]
+        #[meta(#[export(ty_var)] $T:ty where rpl_predicates::is_not_unpin)]
         fn $pattern(..) -> _ = mir! {
             #[export(mut_self)]
             let $self: &mut $Framed;

--- a/crates/rpl_patterns/src/inline/cve_2020_35901_2.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35901_2.rs
@@ -4,7 +4,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{self as hir};
 use rustc_middle::hir::nested_filter::All;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 
 use crate::lints::UNSOUND_PIN_PROJECT;
@@ -110,7 +110,7 @@ fn pattern_pin(pcx: PatCtxt<'_>) -> PatternPin<'_> {
             $field: $S,
         }
 
-        #[meta(#[export(ty_var)] $S:ty = is_not_unpin)]
+        #[meta(#[export(ty_var)] $S:ty = rpl_predicates::is_not_unpin)]
         fn $pattern(..) -> _ = mir! {
             #[export(mut_self)]
             let $self: &mut $SizedStream;
@@ -144,7 +144,7 @@ fn pattern_pin_field(pcx: PatCtxt<'_>) -> PatternPin<'_> {
             $field: $T,
         }
 
-        #[meta(#[export(ty_var)] $T:ty = is_not_unpin)]
+        #[meta(#[export(ty_var)] $T:ty = rpl_predicates::is_not_unpin)]
         fn $pattern(..) -> _ = mir! {
             #[export(mut_self)]
             let $self: &mut $Framed;
@@ -162,9 +162,4 @@ fn pattern_pin_field(pcx: PatCtxt<'_>) -> PatternPin<'_> {
         pin_new,
         ty_var,
     }
-}
-
-#[instrument(level = "debug", skip(tcx), ret)]
-fn is_not_unpin<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-    !ty.is_unpin(tcx, typing_env)
 }

--- a/crates/rpl_patterns/src/inline/cve_2020_35907.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35907.rs
@@ -88,7 +88,7 @@ struct PatternThreadLocalStatic<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     thread_local: pat::Location,
     ret: pat::Location,
-    ty_var: pat::TyVar,
+    ty_var: pat::TyVar<'pcx>,
 }
 
 #[rpl_macros::pattern_def]
@@ -98,7 +98,7 @@ fn pattern_thread_local_static(pcx: PatCtxt<'_>) -> PatternThreadLocalStatic<'_>
     let ret;
     #[allow(non_snake_case)]
     let pattern = rpl! {
-        #[meta(#[export(ty_var)] $T:ty = rpl_predicates::is_sync)]
+        #[meta(#[export(ty_var)] $T:ty where rpl_predicates::is_sync)]
         // FIXME: the return type is not actually checked to be matched
         fn $pattern(..) -> &'static $T = mir! {
             #[export(thread_local)]

--- a/crates/rpl_patterns/src/inline/cve_2020_35907.rs
+++ b/crates/rpl_patterns/src/inline/cve_2020_35907.rs
@@ -4,7 +4,7 @@ use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{self as hir};
 use rustc_middle::hir::nested_filter::All;
-use rustc_middle::ty::{self, Ty, TyCtxt, TypingMode};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{Span, Symbol};
 
 use crate::lints::THREAD_LOCAL_STATIC_REF;
@@ -98,7 +98,7 @@ fn pattern_thread_local_static(pcx: PatCtxt<'_>) -> PatternThreadLocalStatic<'_>
     let ret;
     #[allow(non_snake_case)]
     let pattern = rpl! {
-        #[meta(#[export(ty_var)] $T:ty = is_sync)]
+        #[meta(#[export(ty_var)] $T:ty = rpl_predicates::is_sync)]
         // FIXME: the return type is not actually checked to be matched
         fn $pattern(..) -> &'static $T = mir! {
             #[export(thread_local)]
@@ -121,17 +121,4 @@ fn pattern_thread_local_static(pcx: PatCtxt<'_>) -> PatternThreadLocalStatic<'_>
         ret,
         ty_var,
     }
-}
-
-#[instrument(level = "debug", skip(tcx), ret)]
-fn is_sync<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-    use rustc_infer::infer::TyCtxtInferExt;
-    let infcx = tcx.infer_ctxt().build(TypingMode::PostAnalysis);
-    let trait_def_id = tcx.require_lang_item(hir::LangItem::Sync, None);
-    rustc_trait_selection::traits::type_known_to_meet_bound_modulo_regions(
-        &infcx,
-        typing_env.param_env,
-        ty,
-        trait_def_id,
-    )
 }

--- a/crates/rpl_patterns/src/inline/cve_2021_25904.rs
+++ b/crates/rpl_patterns/src/inline/cve_2021_25904.rs
@@ -129,7 +129,6 @@ fn pattern_from_raw_parts_iter_inlined(pcx: PatCtxt<'_>) -> PatternFromRawParts<
     PatternFromRawParts {
         pattern,
         fn_pat,
-
         src,
         ptr,
         slice,

--- a/crates/rpl_patterns/src/inline/mod.rs
+++ b/crates/rpl_patterns/src/inline/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod alloc_unchecked;
 pub(crate) mod cve_2018_21000;
 pub(crate) mod cve_2019_15548;
 pub(crate) mod cve_2020_25016;
@@ -11,10 +12,8 @@ pub(crate) mod cve_2020_35898_9;
 pub(crate) mod cve_2020_35901_2;
 pub(crate) mod cve_2020_35907;
 pub(crate) mod cve_2021_25904;
-// pub(crate) mod cve_2021_25905;
 pub(crate) mod cve_2021_29941_2;
 pub(crate) mod cve_2024_27284;
-
-pub(crate) mod alloc_unchecked;
 pub(crate) mod transmute_int_to_ptr;
 pub(crate) mod transmute_type_to_bool;
+// pub(crate) mod cve_2021_25905;

--- a/crates/rpl_patterns/src/inline/transmute_int_to_ptr.rs
+++ b/crates/rpl_patterns/src/inline/transmute_int_to_ptr.rs
@@ -1,15 +1,12 @@
 use std::ops::Not;
 
-use either::Either;
 use rpl_context::PatCtxt;
-use rpl_match::resolve::{PatItemKind, def_path_res};
 use rpl_mir::{CheckMirCtxt, pat};
-use rustc_hir::def::Res;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::{self as hir, QPath};
+use rustc_hir::{self as hir};
 use rustc_middle::hir::nested_filter::All;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
 
 #[instrument(level = "info", skip_all)]
@@ -74,7 +71,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
 
                 let translate_to_stmt = matches[pattern_transmute_int_to_ptr.transmute_to];
                 if let rpl_mir::StatementMatch::Location(loc) = translate_to_stmt {
-                    if translate_from_hir_function(self.tcx, loc, body) {
+                    if rpl_predicates::translate_from_hir_function(self.tcx, loc, body, "std::mem::transmute") {
                         self.tcx.emit_node_span_lint(
                             crate::lints::TRANSMUTING_INT_TO_PTR,
                             self.tcx.local_def_id_to_hir_id(def_id),
@@ -111,8 +108,8 @@ fn pattern_transmute_int_to_ptr(pcx: PatCtxt<'_>) -> PatternTransmute<'_> {
     let ptr_ty;
     let pattern = rpl! {
         #[meta(
-            #[export(int_ty)] $INT: ty = is_integral,
-            #[export(ptr_ty)] $PTR:ty = is_ptr
+            #[export(int_ty)] $INT: ty = rpl_predicates::is_integral,
+            #[export(ptr_ty)] $PTR:ty = rpl_predicates::is_ptr
         )]
         fn $pattern (..) -> _ = mir! {
             #[export(transmute_from)]
@@ -132,92 +129,4 @@ fn pattern_transmute_int_to_ptr(pcx: PatCtxt<'_>) -> PatternTransmute<'_> {
         int_ty,
         ptr_ty,
     }
-}
-
-#[instrument(level = "debug", skip(tcx), ret)]
-#[allow(unused_variables)]
-fn is_integral<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.is_integral()
-}
-
-#[instrument(level = "debug", skip(tcx), ret)]
-#[allow(unused_variables)]
-fn is_ptr<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.is_any_ptr()
-}
-
-// Make sure a mir statement is translated from a hir function
-// Example: make sure the following code is translated from `std::mem::transmute`
-// ```rust
-// let _2: bool = move _1 as bool (Transmute);
-// ```
-// Similar to `rustc_trait_selection::error_reporting::traits::FindExprBySpan`
-struct FindExprBySpanAndFnPath<'tcx> {
-    span: Span, // the matched mir statement's span
-    // path: Vec<Symbol>,
-    resolved_res: Vec<Res>, // the path of the function to be translated
-    tcx: TyCtxt<'tcx>,
-    result: Option<&'tcx hir::Expr<'tcx>>,
-}
-
-impl<'tcx> FindExprBySpanAndFnPath<'tcx> {
-    pub fn new(span: Span, path: &str, tcx: TyCtxt<'tcx>) -> Self {
-        let path = path.split("::").map(Symbol::intern).collect::<Vec<_>>();
-        let resolved_res = def_path_res(tcx, &path, PatItemKind::Fn);
-        Self {
-            span,
-            resolved_res,
-            tcx,
-            result: None,
-        }
-    }
-}
-
-impl<'v> Visitor<'v> for FindExprBySpanAndFnPath<'v> {
-    type NestedFilter = rustc_middle::hir::nested_filter::OnlyBodies;
-
-    fn nested_visit_map(&mut self) -> Self::Map {
-        self.tcx.hir()
-    }
-
-    fn visit_expr(&mut self, ex: &'v hir::Expr<'v>) {
-        if self.span == ex.span
-            && let hir::ExprKind::Call(callee, _args) = ex.kind
-            && let hir::ExprKind::Path(path) = callee.kind
-            && let QPath::Resolved(_, path) = path
-            && self.resolved_res.contains(&path.res)
-        {
-            self.result = Some(ex);
-            debug!("mir_span: {:?}", self.span);
-            debug!("expr_span: {:?}", ex.span);
-            debug!("resolved_res: {:?}", self.resolved_res);
-            debug!("path.res: {:?}", path.res);
-        } else {
-            hir::intravisit::walk_expr(self, ex);
-        }
-    }
-}
-
-pub fn translate_from_hir_function(
-    tcx: TyCtxt<'_>,
-    mir_location: rustc_middle::mir::Location,
-    body: &rustc_middle::mir::Body<'_>,
-) -> bool {
-    let mir_stmt = body.stmt_at(mir_location);
-    let (span, scope) = match mir_stmt {
-        Either::Left(stmt) => (stmt.source_info.span, stmt.source_info.scope),
-        Either::Right(terminator) => (terminator.source_info.span, terminator.source_info.scope),
-    };
-    let Some(hir_id) = scope.lint_root(&body.source_scopes) else {
-        return false;
-    };
-    let body_id = tcx.hir_node(hir_id).expect_item().expect_fn().2;
-
-    let mut expr_finder = FindExprBySpanAndFnPath::new(span, "std::mem::transmute", tcx);
-    expr_finder.visit_expr(tcx.hir().body(body_id).value);
-    let Some(expr) = expr_finder.result else {
-        return false;
-    };
-    trace!("expr: {:?}", expr);
-    true
 }

--- a/crates/rpl_patterns/src/inline/transmute_int_to_ptr.rs
+++ b/crates/rpl_patterns/src/inline/transmute_int_to_ptr.rs
@@ -96,8 +96,8 @@ struct PatternTransmute<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     transmute_from: pat::Location,
     transmute_to: pat::Location,
-    int_ty: pat::TyVar,
-    ptr_ty: pat::TyVar,
+    int_ty: pat::TyVar<'pcx>,
+    ptr_ty: pat::TyVar<'pcx>,
 }
 
 #[rpl_macros::pattern_def]
@@ -108,8 +108,8 @@ fn pattern_transmute_int_to_ptr(pcx: PatCtxt<'_>) -> PatternTransmute<'_> {
     let ptr_ty;
     let pattern = rpl! {
         #[meta(
-            #[export(int_ty)] $INT: ty = rpl_predicates::is_integral,
-            #[export(ptr_ty)] $PTR:ty = rpl_predicates::is_ptr
+            #[export(int_ty)] $INT:ty where rpl_predicates::is_integral,
+            #[export(ptr_ty)] $PTR:ty where rpl_predicates::is_ptr
         )]
         fn $pattern (..) -> _ = mir! {
             #[export(transmute_from)]

--- a/crates/rpl_patterns/src/inline/transmute_type_to_bool.rs
+++ b/crates/rpl_patterns/src/inline/transmute_type_to_bool.rs
@@ -1,13 +1,10 @@
 use std::ops::Not;
 
-use either::Either;
 use rpl_context::PatCtxt;
-use rpl_match::resolve::{PatItemKind, def_path_res};
 use rpl_mir::{CheckMirCtxt, pat};
-use rustc_hir::def::Res;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::{self as hir, QPath};
+use rustc_hir::{self as hir};
 use rustc_middle::hir::nested_filter::All;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
@@ -73,7 +70,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
 
                 let translate_to_stmt = matches[pattern_transmute_to_bool.transmute_to];
                 if let rpl_mir::StatementMatch::Location(loc) = translate_to_stmt {
-                    if translate_from_hir_function(self.tcx, loc, body) {
+                    if rpl_predicates::translate_from_hir_function(self.tcx, loc, body, "std::mem::transmute") {
                         self.tcx.emit_node_span_lint(
                             crate::lints::TRANSMUTING_TYPE_TO_BOOL,
                             self.tcx.local_def_id_to_hir_id(def_id),
@@ -125,80 +122,4 @@ fn pattern_transmute_to_bool(pcx: PatCtxt<'_>) -> PatternTransmute<'_> {
         transmute_to,
         ty_var,
     }
-}
-
-// Make sure a mir statement is translated from a hir function
-// Example: make sure the following code is translated from `std::mem::transmute`
-// ```rust
-// let _2: bool = move _1 as bool (Transmute);
-// ```
-// Similar to `rustc_trait_selection::error_reporting::traits::FindExprBySpan`
-struct FindExprBySpanAndFnPath<'tcx> {
-    span: Span, // the matched mir statement's span
-    // path: Vec<Symbol>,
-    resolved_res: Vec<Res>, // the path of the function to be translated
-    tcx: TyCtxt<'tcx>,
-    result: Option<&'tcx hir::Expr<'tcx>>,
-}
-
-impl<'tcx> FindExprBySpanAndFnPath<'tcx> {
-    pub fn new(span: Span, path: &str, tcx: TyCtxt<'tcx>) -> Self {
-        let path = path.split("::").map(Symbol::intern).collect::<Vec<_>>();
-        let resolved_res = def_path_res(tcx, &path, PatItemKind::Fn);
-        Self {
-            span,
-            resolved_res,
-            tcx,
-            result: None,
-        }
-    }
-}
-
-impl<'v> Visitor<'v> for FindExprBySpanAndFnPath<'v> {
-    type NestedFilter = rustc_middle::hir::nested_filter::OnlyBodies;
-
-    fn nested_visit_map(&mut self) -> Self::Map {
-        self.tcx.hir()
-    }
-
-    fn visit_expr(&mut self, ex: &'v hir::Expr<'v>) {
-        if self.span == ex.span
-            && let hir::ExprKind::Call(callee, _args) = ex.kind
-            && let hir::ExprKind::Path(path) = callee.kind
-            && let QPath::Resolved(_, path) = path
-            && self.resolved_res.contains(&path.res)
-        {
-            self.result = Some(ex);
-            debug!("mir_span: {:?}", self.span);
-            debug!("expr_span: {:?}", ex.span);
-            debug!("resolved_res: {:?}", self.resolved_res);
-            debug!("path.res: {:?}", path.res);
-        } else {
-            hir::intravisit::walk_expr(self, ex);
-        }
-    }
-}
-
-pub fn translate_from_hir_function(
-    tcx: TyCtxt<'_>,
-    mir_location: rustc_middle::mir::Location,
-    body: &rustc_middle::mir::Body<'_>,
-) -> bool {
-    let mir_stmt = body.stmt_at(mir_location);
-    let (span, scope) = match mir_stmt {
-        Either::Left(stmt) => (stmt.source_info.span, stmt.source_info.scope),
-        Either::Right(terminator) => (terminator.source_info.span, terminator.source_info.scope),
-    };
-    let Some(hir_id) = scope.lint_root(&body.source_scopes) else {
-        return false;
-    };
-    let body_id = tcx.hir_node(hir_id).expect_item().expect_fn().2;
-
-    let mut expr_finder = FindExprBySpanAndFnPath::new(span, "std::mem::transmute", tcx);
-    expr_finder.visit_expr(tcx.hir().body(body_id).value);
-    let Some(expr) = expr_finder.result else {
-        return false;
-    };
-    trace!("expr: {:?}", expr);
-    true
 }

--- a/crates/rpl_patterns/src/inline/transmute_type_to_bool.rs
+++ b/crates/rpl_patterns/src/inline/transmute_type_to_bool.rs
@@ -94,7 +94,7 @@ struct PatternTransmute<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     transmute_from: pat::Location,
     transmute_to: pat::Location,
-    ty_var: pat::TyVar,
+    ty_var: pat::TyVar<'pcx>,
 }
 
 // The pattern for transmuting a type to a boolean

--- a/crates/rpl_patterns/src/lib.rs
+++ b/crates/rpl_patterns/src/lib.rs
@@ -68,7 +68,6 @@ static ALL_PATTERNS: &[fn(TyCtxt<'_>, PatCtxt<'_>, ItemId)] = &[
     inline::cve_2024_27284::check_item,
     others::private_or_generic_function_marked_inline::check_item,
     inline::transmute_type_to_bool::check_item,
-    // FIXME: Too loose
     inline::transmute_int_to_ptr::check_item,
     normal::manually_drop::check_item,
     inline::alloc_unchecked::check_item,

--- a/crates/rpl_patterns/src/normal/alloc_unchecked.rs
+++ b/crates/rpl_patterns/src/normal/alloc_unchecked.rs
@@ -4,7 +4,7 @@ use rustc_hir::intravisit::{self, Visitor};
 use rustc_middle::hir::nested_filter::All;
 use rustc_middle::mir;
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::{Span, Symbol, sym};
+use rustc_span::{Span, Symbol};
 
 use rpl_context::{PatCtxt, pat};
 use rpl_mir::CheckMirCtxt;
@@ -127,7 +127,10 @@ fn alloc_misaligned_cast(pcx: PatCtxt<'_>) -> Pattern2<'_> {
     let ty;
     let alignment;
     let pattern = rpl! {
-        #[meta(#[export(ty)] $T:ty = is_all_safe_trait, #[export(alignment)] $alignment: const(usize))]
+        #[meta(
+            #[export(ty)] $T:ty = rpl_predicates::is_all_safe_trait,
+            #[export(alignment)] $alignment: const(usize)
+        )]
         fn $pattern(..) -> _ = mir! {
             let $layout_result: core::result::Result<core::alloc::Layout, _> = alloc::alloc::Layout::from_size_align(
                 _,
@@ -150,26 +153,6 @@ fn alloc_misaligned_cast(pcx: PatCtxt<'_>) -> Pattern2<'_> {
         ty,
         alignment,
     }
-}
-
-#[instrument(level = "debug", skip(tcx), ret)]
-fn is_all_safe_trait<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, self_ty: Ty<'tcx>) -> bool {
-    // Some unsafe traits that are not related to alignment
-    const EXCLUDED_DIAG_ITEMS: &[Symbol] = &[sym::Send, sym::Sync];
-    typing_env
-        .param_env
-        .caller_bounds()
-        .iter()
-        .filter_map(|clause| clause.as_trait_clause())
-        .filter(|clause| clause.self_ty().no_bound_vars().expect("Unhandled bound vars") == self_ty)
-        .map(|clause| clause.def_id())
-        .filter(|&def_id| {
-            tcx.get_diagnostic_name(def_id)
-                .is_none_or(|name| !EXCLUDED_DIAG_ITEMS.contains(&name))
-        })
-        .map(|def_id| tcx.trait_def(def_id))
-        .inspect(|trait_def| debug!(?trait_def))
-        .all(|trait_def| matches!(trait_def.safety, hir::Safety::Safe))
 }
 
 #[instrument(level = "debug", skip(tcx), ret)]

--- a/crates/rpl_patterns/src/normal/alloc_unchecked.rs
+++ b/crates/rpl_patterns/src/normal/alloc_unchecked.rs
@@ -116,7 +116,7 @@ struct Pattern2<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     alloc: pat::Location,
     cast: pat::Location,
-    ty: pat::TyVar,
+    ty: pat::TyVar<'pcx>,
     alignment: pat::ConstVar<'pcx>,
 }
 
@@ -128,7 +128,8 @@ fn alloc_misaligned_cast(pcx: PatCtxt<'_>) -> Pattern2<'_> {
     let alignment;
     let pattern = rpl! {
         #[meta(
-            #[export(ty)] $T:ty = rpl_predicates::is_all_safe_trait,
+            #[export(ty)] $T:ty
+                where rpl_predicates::is_all_safe_trait,
             #[export(alignment)] $alignment: const(usize)
         )]
         fn $pattern(..) -> _ = mir! {
@@ -181,7 +182,7 @@ struct Pattern3<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     realloc: pat::Location,
     deref: pat::Location,
-    ty: pat::TyVar,
+    ty: pat::TyVar<'pcx>,
 }
 
 #[rpl_macros::pattern_def]

--- a/crates/rpl_patterns/src/normal/cve_2019_15548.rs
+++ b/crates/rpl_patterns/src/normal/cve_2019_15548.rs
@@ -148,7 +148,6 @@ fn pattern_pass_a_pointer_to_c(pcx: PatCtxt<'_>) -> PatternPointer<'_> {
     PatternPointer {
         pattern,
         fn_pat,
-
         ptr,
         // ty_var: c_char_ty,
     }

--- a/crates/rpl_patterns/src/normal/cve_2020_35907.rs
+++ b/crates/rpl_patterns/src/normal/cve_2020_35907.rs
@@ -4,7 +4,7 @@ use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{self as hir};
 use rustc_middle::hir::nested_filter::All;
-use rustc_middle::ty::{self, Ty, TyCtxt, TypingMode};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{Span, Symbol};
 
 use crate::lints::THREAD_LOCAL_STATIC_REF;
@@ -99,7 +99,7 @@ fn pattern_thread_local_static(pcx: PatCtxt<'_>) -> PatternThreadLocalStatic<'_>
     let ret;
     #[allow(non_snake_case)]
     let pattern = rpl! {
-        #[meta(#[export(ty_var)] $T:ty = is_sync)]
+        #[meta(#[export(ty_var)] $T:ty = rpl_predicates::is_sync)]
         // FIXME: the return type is not actually checked to be matched
         fn $pattern(..) -> &'static $T = mir! {
             #[export(thread_local)]
@@ -118,17 +118,4 @@ fn pattern_thread_local_static(pcx: PatCtxt<'_>) -> PatternThreadLocalStatic<'_>
         ret,
         ty_var,
     }
-}
-
-#[instrument(level = "debug", skip(tcx), ret)]
-fn is_sync<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-    use rustc_infer::infer::TyCtxtInferExt;
-    let infcx = tcx.infer_ctxt().build(TypingMode::PostAnalysis);
-    let trait_def_id = tcx.require_lang_item(hir::LangItem::Sync, None);
-    rustc_trait_selection::traits::type_known_to_meet_bound_modulo_regions(
-        &infcx,
-        typing_env.param_env,
-        ty,
-        trait_def_id,
-    )
 }

--- a/crates/rpl_patterns/src/normal/cve_2020_35907.rs
+++ b/crates/rpl_patterns/src/normal/cve_2020_35907.rs
@@ -89,7 +89,7 @@ struct PatternThreadLocalStatic<'pcx> {
     fn_pat: &'pcx pat::Fn<'pcx>,
     thread_local: pat::Location,
     ret: pat::Location,
-    ty_var: pat::TyVar,
+    ty_var: pat::TyVar<'pcx>,
 }
 
 #[rpl_macros::pattern_def]
@@ -99,7 +99,7 @@ fn pattern_thread_local_static(pcx: PatCtxt<'_>) -> PatternThreadLocalStatic<'_>
     let ret;
     #[allow(non_snake_case)]
     let pattern = rpl! {
-        #[meta(#[export(ty_var)] $T:ty = rpl_predicates::is_sync)]
+        #[meta(#[export(ty_var)] $T:ty where rpl_predicates::is_sync)]
         // FIXME: the return type is not actually checked to be matched
         fn $pattern(..) -> &'static $T = mir! {
             #[export(thread_local)]

--- a/crates/rpl_patterns/src/normal/cve_2021_25904.rs
+++ b/crates/rpl_patterns/src/normal/cve_2021_25904.rs
@@ -102,7 +102,6 @@ fn pattern_from_raw_parts_iter(pcx: PatCtxt<'_>) -> PatternFromRawParts<'_> {
     PatternFromRawParts {
         pattern,
         fn_pat,
-
         src,
         ptr,
         slice,

--- a/crates/rpl_patterns/src/normal/mod.rs
+++ b/crates/rpl_patterns/src/normal/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod alloc_unchecked;
 pub(crate) mod cve_2018_20992;
 pub(crate) mod cve_2018_21000;
 pub(crate) mod cve_2019_15548;
@@ -9,6 +10,4 @@ pub(crate) mod cve_2021_25905;
 pub(crate) mod cve_2021_27376;
 pub(crate) mod cve_2021_29941_2;
 pub(crate) mod cve_2022_23639;
-
-pub(crate) mod alloc_unchecked;
 pub(crate) mod manually_drop;

--- a/crates/rpl_predicates/Cargo.toml
+++ b/crates/rpl_predicates/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rpl_predicates"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+publish.workspace = true
+license.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+[dependencies]
+tracing.workspace = true
+rpl_match.workspace = true
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true

--- a/crates/rpl_predicates/src/lib.rs
+++ b/crates/rpl_predicates/src/lib.rs
@@ -1,0 +1,28 @@
+#![feature(rustc_private)]
+#![feature(let_chains)]
+#![feature(if_let_guard)]
+
+extern crate rustc_data_structures;
+extern crate rustc_driver;
+extern crate rustc_errors;
+extern crate rustc_fluent_macro;
+extern crate rustc_hir;
+extern crate rustc_infer;
+extern crate rustc_lint_defs;
+extern crate rustc_macros;
+extern crate rustc_middle;
+extern crate rustc_passes;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate rustc_trait_selection;
+#[macro_use]
+extern crate tracing;
+extern crate either;
+
+mod trait_bound;
+mod translate;
+mod ty;
+
+pub use trait_bound::*;
+pub use translate::*;
+pub use ty::*;

--- a/crates/rpl_predicates/src/trait_bound.rs
+++ b/crates/rpl_predicates/src/trait_bound.rs
@@ -1,0 +1,46 @@
+use rustc_hir as hir;
+use rustc_middle::ty::{self, Ty, TyCtxt, TypingMode};
+use rustc_span::{Symbol, sym};
+
+/// Check if self_ty's trait bounds are all safe.
+#[instrument(level = "debug", skip(tcx), ret)]
+pub fn is_all_safe_trait<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, self_ty: Ty<'tcx>) -> bool {
+    if self_ty.is_primitive() {
+        return false;
+    }
+    const EXCLUDED_DIAG_ITEMS: &[Symbol] = &[sym::Send, sym::Sync];
+    typing_env
+        .param_env
+        .caller_bounds()
+        .iter()
+        .filter_map(|clause| clause.as_trait_clause())
+        .filter(|clause| clause.self_ty().no_bound_vars().expect("Unhandled bound vars") == self_ty)
+        .map(|clause| clause.def_id())
+        .filter(|&def_id| {
+            tcx.get_diagnostic_name(def_id)
+                .is_none_or(|name| !EXCLUDED_DIAG_ITEMS.contains(&name))
+        })
+        .map(|def_id| tcx.trait_def(def_id))
+        .inspect(|trait_def| debug!(?trait_def))
+        .all(|trait_def| matches!(trait_def.safety, hir::Safety::Safe))
+}
+
+/// Check if ty is not unpin.
+#[instrument(level = "debug", skip(tcx), ret)]
+pub fn is_not_unpin<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
+    !ty.is_unpin(tcx, typing_env)
+}
+
+/// Check if ty is sync.
+#[instrument(level = "debug", skip(tcx), ret)]
+pub fn is_sync<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
+    use rustc_infer::infer::TyCtxtInferExt;
+    let infcx = tcx.infer_ctxt().build(TypingMode::PostAnalysis);
+    let trait_def_id = tcx.require_lang_item(hir::LangItem::Sync, None);
+    rustc_trait_selection::traits::type_known_to_meet_bound_modulo_regions(
+        &infcx,
+        typing_env.param_env,
+        ty,
+        trait_def_id,
+    )
+}

--- a/crates/rpl_predicates/src/trait_bound.rs
+++ b/crates/rpl_predicates/src/trait_bound.rs
@@ -5,9 +5,6 @@ use rustc_span::{Symbol, sym};
 /// Check if self_ty's trait bounds are all safe.
 #[instrument(level = "debug", skip(tcx), ret)]
 pub fn is_all_safe_trait<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, self_ty: Ty<'tcx>) -> bool {
-    if self_ty.is_primitive() {
-        return false;
-    }
     const EXCLUDED_DIAG_ITEMS: &[Symbol] = &[sym::Send, sym::Sync];
     typing_env
         .param_env

--- a/crates/rpl_predicates/src/translate.rs
+++ b/crates/rpl_predicates/src/translate.rs
@@ -1,0 +1,115 @@
+use either::Either;
+use rpl_match::resolve::{PatItemKind, def_path_res};
+use rustc_hir::def::Res;
+use rustc_hir::intravisit::Visitor;
+use rustc_hir::{
+    self as hir, BodyId, ImplItem, ImplItemKind, Item, ItemKind, Node, QPath, TraitFn, TraitItem, TraitItemKind,
+};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::{Span, Symbol};
+
+// Make sure a mir statement is translated from a hir function
+// Example: make sure the following code is translated from `std::mem::transmute`
+// ```rust
+// let _2: bool = move _1 as bool (Transmute);
+// ```
+// Similar to `rustc_trait_selection::error_reporting::traits::FindExprBySpan`
+struct FindExprBySpanAndFnPath<'tcx> {
+    span: Span, // the matched mir statement's span
+    // path: Vec<Symbol>,
+    resolved_res: Vec<Res>, // the path of the function to be translated
+    tcx: TyCtxt<'tcx>,
+    result: Option<&'tcx hir::Expr<'tcx>>,
+}
+
+impl<'tcx> FindExprBySpanAndFnPath<'tcx> {
+    pub fn new(span: Span, path: &str, tcx: TyCtxt<'tcx>) -> Self {
+        let path = path.split("::").map(Symbol::intern).collect::<Vec<_>>();
+        let resolved_res = def_path_res(tcx, &path, PatItemKind::Fn);
+        Self {
+            span,
+            resolved_res,
+            tcx,
+            result: None,
+        }
+    }
+}
+
+impl<'v> Visitor<'v> for FindExprBySpanAndFnPath<'v> {
+    type NestedFilter = rustc_middle::hir::nested_filter::OnlyBodies;
+
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.tcx.hir()
+    }
+
+    fn visit_expr(&mut self, ex: &'v hir::Expr<'v>) {
+        if self.span == ex.span
+            && let hir::ExprKind::Call(callee, _args) = ex.kind
+            && let hir::ExprKind::Path(path) = callee.kind
+            && let QPath::Resolved(_, path) = path
+            && self.resolved_res.contains(&path.res)
+        {
+            self.result = Some(ex);
+            debug!("mir_span: {:?}", self.span);
+            debug!("expr_span: {:?}", ex.span);
+            debug!("resolved_res: {:?}", self.resolved_res);
+            debug!("path.res: {:?}", path.res);
+        } else {
+            hir::intravisit::walk_expr(self, ex);
+        }
+    }
+}
+
+pub fn get_body_id_from_hir_node(node: Node<'_>) -> Option<BodyId> {
+    match node {
+        Node::TraitItem(TraitItem {
+            kind: TraitItemKind::Fn(_fn_sig, trait_fn),
+            ..
+        }) => match trait_fn {
+            TraitFn::Provided(body_id) => Some(*body_id),
+            _ => None,
+        },
+        Node::ImplItem(ImplItem {
+            kind: ImplItemKind::Fn(_fn_sig, body_id),
+            ..
+        }) => Some(*body_id),
+        Node::Item(Item {
+            kind:
+                ItemKind::Fn {
+                    sig: _,
+                    generics: _,
+                    body: body_id,
+                    has_body: _,
+                },
+            ..
+        }) => Some(*body_id),
+        _ => None,
+    }
+}
+
+pub fn translate_from_hir_function(
+    tcx: TyCtxt<'_>,
+    mir_location: rustc_middle::mir::Location,
+    body: &rustc_middle::mir::Body<'_>,
+    hir_fn_path: &str,
+) -> bool {
+    let mir_stmt = body.stmt_at(mir_location);
+    let (span, scope) = match mir_stmt {
+        Either::Left(stmt) => (stmt.source_info.span, stmt.source_info.scope),
+        Either::Right(terminator) => (terminator.source_info.span, terminator.source_info.scope),
+    };
+    let Some(hir_id) = scope.lint_root(&body.source_scopes) else {
+        return false;
+    };
+    let Some(body_id) = get_body_id_from_hir_node(tcx.hir_node(hir_id)) else {
+        return false;
+    };
+
+    let mut expr_finder = FindExprBySpanAndFnPath::new(span, hir_fn_path, tcx);
+    expr_finder.visit_expr(tcx.hir().body(body_id).value);
+    let Some(expr) = expr_finder.result else {
+        return false;
+    };
+    trace!("expr: {:?}", expr);
+    true
+}

--- a/crates/rpl_predicates/src/translate.rs
+++ b/crates/rpl_predicates/src/translate.rs
@@ -63,12 +63,9 @@ impl<'v> Visitor<'v> for FindExprBySpanAndFnPath<'v> {
 pub fn get_body_id_from_hir_node(node: Node<'_>) -> Option<BodyId> {
     match node {
         Node::TraitItem(TraitItem {
-            kind: TraitItemKind::Fn(_fn_sig, trait_fn),
+            kind: TraitItemKind::Fn(_fn_sig, TraitFn::Provided(body_id)),
             ..
-        }) => match trait_fn {
-            TraitFn::Provided(body_id) => Some(*body_id),
-            _ => None,
-        },
+        }) => Some(*body_id),
         Node::ImplItem(ImplItem {
             kind: ImplItemKind::Fn(_fn_sig, body_id),
             ..

--- a/crates/rpl_predicates/src/ty.rs
+++ b/crates/rpl_predicates/src/ty.rs
@@ -11,3 +11,8 @@ pub fn is_integral<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty:
 pub fn is_ptr<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
     ty.is_any_ptr()
 }
+
+#[allow(unused_variables)]
+pub fn is_primitive<'tcx>(_tcx: TyCtxt<'tcx>, _typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
+    ty.is_primitive()
+}

--- a/crates/rpl_predicates/src/ty.rs
+++ b/crates/rpl_predicates/src/ty.rs
@@ -1,0 +1,13 @@
+use rustc_middle::ty::{self, Ty, TyCtxt};
+
+#[instrument(level = "debug", skip(tcx), ret)]
+#[allow(unused_variables)]
+pub fn is_integral<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
+    ty.is_integral()
+}
+
+#[instrument(level = "debug", skip(tcx), ret)]
+#[allow(unused_variables)]
+pub fn is_ptr<'tcx>(tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>, ty: Ty<'tcx>) -> bool {
+    ty.is_any_ptr()
+}

--- a/tests/ui/cve_2020_35887/minimal.regular.stderr
+++ b/tests/ui/cve_2020_35887/minimal.regular.stderr
@@ -22,16 +22,5 @@ LL |     let ptr = unsafe { alloc(layout) as *mut Align32 };
    |
    = note: See https://doc.rust-lang.org/std/alloc/fn.alloc.html and https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
 
-error: resulting pointer `*mut u64` has a different alignment than the original alignment that the pointer was created with
-  --> tests/ui/cve_2020_35887/minimal.rs:42:24
-   |
-LL |     let ptr = unsafe { alloc(layout) as *mut u64 };
-   |                        -------------^^^^^^^^^^^^
-   |                        |
-   |                        pointer created here
-   |                        pointer casted here
-   |
-   = note: See https://doc.rust-lang.org/std/alloc/fn.alloc.html and https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/cve_2020_35887/minimal.regular.stderr
+++ b/tests/ui/cve_2020_35887/minimal.regular.stderr
@@ -22,5 +22,16 @@ LL |     let ptr = unsafe { alloc(layout) as *mut Align32 };
    |
    = note: See https://doc.rust-lang.org/std/alloc/fn.alloc.html and https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
 
-error: aborting due to 2 previous errors
+error: resulting pointer `*mut u64` has a different alignment than the original alignment that the pointer was created with
+  --> tests/ui/cve_2020_35887/minimal.rs:42:24
+   |
+LL |     let ptr = unsafe { alloc(layout) as *mut u64 };
+   |                        -------------^^^^^^^^^^^^
+   |                        |
+   |                        pointer created here
+   |                        pointer casted here
+   |
+   = note: See https://doc.rust-lang.org/std/alloc/fn.alloc.html and https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/std/mem/transmute/int2ptr.rs
+++ b/tests/ui/std/mem/transmute/int2ptr.rs
@@ -26,4 +26,16 @@ pub fn transmute_u64_to_mut_ptr(x: u64) {
     println!("{}", unsafe { *ptr_u64 });
 }
 
+struct S {
+    s: u64,
+}
+
+impl S {
+    pub fn transmute_u64_to_mut_ptr(x: u64) -> *mut u64 {
+        //~^ERROR: it is unsound to transmute an integer type `u64` to a pointer type `*mut ()`
+        let ptr: *mut () = unsafe { transmute(x) };
+        ptr as *mut u64
+    }
+}
+
 fn main() {}

--- a/tests/ui/std/mem/transmute/int2ptr.stderr
+++ b/tests/ui/std/mem/transmute/int2ptr.stderr
@@ -36,5 +36,17 @@ LL |     let ptr: *mut () = unsafe { transmute(x) };
    = help: See https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers
    = note: transmuting integers to pointers is a largely unspecified operation
 
-error: aborting due to 3 previous errors
+error: it is unsound to transmute an integer type `u64` to a pointer type `*mut ()`
+  --> tests/ui/std/mem/transmute/int2ptr.rs:34:37
+   |
+LL |     pub fn transmute_u64_to_mut_ptr(x: u64) -> *mut u64 {
+   |                                     ^ transmuted from here
+LL |
+LL |         let ptr: *mut () = unsafe { transmute(x) };
+   |                                     ------------ transmuted to here
+   |
+   = help: See https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers
+   = note: transmuting integers to pointers is a largely unspecified operation
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
- Organize RPL predicates into new crate
- Support predicates in conjunction form after type meta variables, changed the separator from `=` to `where`; cc @TheVeryDarkness
- Fix a may-panic bug in predicate `translate_from_hir_function`