### PR TITLE
feat(rpl): add item-pattern matching and Send/Sync variance predicates

### DIFF
--- a/crates/rpl_constraints/src/lib.rs
+++ b/crates/rpl_constraints/src/lib.rs
@@ -44,6 +44,7 @@ pub mod tribool;
 pub struct Constraints {
     pub preds: Vec<predicates::PredicateConjunction>,
     pub attrs: attributes::FnAttr,
+    pub has_attributes: bool,
 }
 
 impl Constraints {
@@ -52,6 +53,8 @@ impl Constraints {
         where_block: &Option<pairs::WhereBlock<'i>>,
         path: &'i std::path::Path,
     ) -> Result<Self, PredicateError<'i>> {
+        let mut pre_attrs = pre_attrs.peekable();
+        let has_pre_attrs = pre_attrs.peek().is_some();
         if let Some(where_block) = where_block
             && let Some(constraints) = where_block.ConstraintsSeparatedByComma()
         {
@@ -70,12 +73,21 @@ impl Constraints {
                     }
                     Ok((preds, attrs))
                 })?;
+            let has_attributes = has_pre_attrs || !attrs.is_empty();
             let attrs = FnAttr::parse(pre_attrs, &attrs);
-            Ok(Self { preds, attrs })
+            Ok(Self {
+                preds,
+                attrs,
+                has_attributes,
+            })
         } else {
             let preds = Vec::new();
             let attrs = FnAttr::parse(pre_attrs, &[]);
-            Ok(Self { preds, attrs })
+            Ok(Self {
+                preds,
+                attrs,
+                has_attributes: has_pre_attrs,
+            })
         }
     }
 }

--- a/crates/rpl_constraints/src/predicates/item.rs
+++ b/crates/rpl_constraints/src/predicates/item.rs
@@ -12,11 +12,13 @@ pub enum ItemPredicate {
     /// Decides whether the resource satisfies `Sync` under the correlated access's applicability
     /// context and the matched impl substitution.
     IsSyncForAccessIn,
-    /// Emits correlated access witnesses and resource types whose exclusive authority can cross
-    /// threads through safe operations that start from a shared reference to the wrapper.
+    /// Emits access/resource pairs, correlated with the supplied parameter mapping and matched
+    /// impl applicability, whose exclusive authority can cross threads through safe operations
+    /// that start from a shared reference to the wrapper.
     ResourceExclusivelyAccessibleFromSharedRefIn,
-    /// Emits correlated access witnesses and resource types that safe operations starting from a
-    /// shared reference to the wrapper can access concurrently.
+    /// Emits access/resource pairs, correlated with the supplied parameter mapping and matched
+    /// impl applicability, that safe operations starting from a shared reference to the wrapper
+    /// can access concurrently.
     ResourceConcurrentlyAccessibleFromSharedRefIn,
 }
 

--- a/crates/rpl_constraints/src/predicates/item.rs
+++ b/crates/rpl_constraints/src/predicates/item.rs
@@ -5,6 +5,7 @@ pub enum ItemPredicate {
     TypeParameterMapsTo,
     OwnsType,
     IsSendIn,
+    IsSyncIn,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -73,6 +74,8 @@ const TYPE_PARAMETER_MAPS_TO_ARGS: &[ItemPredicateArgSpec] = &[
 const OWNS_TYPE_ARGS: &[ItemPredicateArgSpec] = &[ItemPredicateArgSpec::input(Adt), ItemPredicateArgSpec::input(Type)];
 const IS_SEND_IN_ARGS: &[ItemPredicateArgSpec] =
     &[ItemPredicateArgSpec::input(Type), ItemPredicateArgSpec::input(Impl)];
+const IS_SYNC_IN_ARGS: &[ItemPredicateArgSpec] =
+    &[ItemPredicateArgSpec::input(Type), ItemPredicateArgSpec::input(Impl)];
 
 const TRUE: ItemPredicateSpec = ItemPredicateSpec {
     predicate: None,
@@ -109,6 +112,11 @@ const IS_SEND_IN: ItemPredicateSpec = ItemPredicateSpec {
     name: "is_send_in",
     args: IS_SEND_IN_ARGS,
 };
+const IS_SYNC_IN: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::IsSyncIn),
+    name: "is_sync_in",
+    args: IS_SYNC_IN_ARGS,
+};
 
 pub fn item_predicate_spec(name: &str) -> Option<&'static ItemPredicateSpec> {
     match name {
@@ -119,6 +127,7 @@ pub fn item_predicate_spec(name: &str) -> Option<&'static ItemPredicateSpec> {
         "type_parameter_maps_to" => Some(&TYPE_PARAMETER_MAPS_TO),
         "owns_type" => Some(&OWNS_TYPE),
         "is_send_in" => Some(&IS_SEND_IN),
+        "is_sync_in" => Some(&IS_SYNC_IN),
         _ => None,
     }
 }
@@ -140,5 +149,11 @@ mod tests {
         assert_eq!(maps_to.args.len(), 3);
         assert_eq!(maps_to.args[1].mode, ItemPredicateArgMode::Output);
         assert_eq!(maps_to.args[2].kind, ItemPredicateArgKind::Impl);
+
+        let is_sync_in = item_predicate_spec("is_sync_in").expect("registered predicate");
+        assert_eq!(is_sync_in.args.len(), 2);
+        assert_eq!(is_sync_in.args[0].mode, ItemPredicateArgMode::Input);
+        assert_eq!(is_sync_in.args[0].kind, ItemPredicateArgKind::Type);
+        assert_eq!(is_sync_in.args[1].kind, ItemPredicateArgKind::Impl);
     }
 }

--- a/crates/rpl_constraints/src/predicates/item.rs
+++ b/crates/rpl_constraints/src/predicates/item.rs
@@ -1,0 +1,144 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ItemPredicate {
+    HasTypeParameters,
+    TypeParameterOf,
+    TypeParameterMapsTo,
+    OwnsType,
+    IsSendIn,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ItemPredicateArgMode {
+    Input,
+    Output,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ItemPredicateArgKind {
+    Adt,
+    Type,
+    Impl,
+}
+
+impl ItemPredicateArgKind {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Adt => "adt",
+            Self::Type => "type",
+            Self::Impl => "impl binding",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ItemPredicateArgSpec {
+    pub mode: ItemPredicateArgMode,
+    pub kind: ItemPredicateArgKind,
+}
+
+impl ItemPredicateArgSpec {
+    const fn input(kind: ItemPredicateArgKind) -> Self {
+        Self {
+            mode: ItemPredicateArgMode::Input,
+            kind,
+        }
+    }
+
+    const fn output(kind: ItemPredicateArgKind) -> Self {
+        Self {
+            mode: ItemPredicateArgMode::Output,
+            kind,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ItemPredicateSpec {
+    pub predicate: Option<ItemPredicate>,
+    pub name: &'static str,
+    pub args: &'static [ItemPredicateArgSpec],
+}
+
+use ItemPredicateArgKind::{Adt, Impl, Type};
+
+const NO_ARGS: &[ItemPredicateArgSpec] = &[];
+const ADT_INPUT: &[ItemPredicateArgSpec] = &[ItemPredicateArgSpec::input(Adt)];
+const TYPE_PARAMETER_OF_ARGS: &[ItemPredicateArgSpec] =
+    &[ItemPredicateArgSpec::output(Type), ItemPredicateArgSpec::input(Adt)];
+const TYPE_PARAMETER_MAPS_TO_ARGS: &[ItemPredicateArgSpec] = &[
+    ItemPredicateArgSpec::input(Type),
+    ItemPredicateArgSpec::output(Type),
+    ItemPredicateArgSpec::input(Impl),
+];
+const OWNS_TYPE_ARGS: &[ItemPredicateArgSpec] = &[ItemPredicateArgSpec::input(Adt), ItemPredicateArgSpec::input(Type)];
+const IS_SEND_IN_ARGS: &[ItemPredicateArgSpec] =
+    &[ItemPredicateArgSpec::input(Type), ItemPredicateArgSpec::input(Impl)];
+
+const TRUE: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: None,
+    name: "true",
+    args: NO_ARGS,
+};
+const FALSE: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: None,
+    name: "false",
+    args: NO_ARGS,
+};
+const HAS_TYPE_PARAMETERS: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::HasTypeParameters),
+    name: "has_type_parameters",
+    args: ADT_INPUT,
+};
+const TYPE_PARAMETER_OF: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::TypeParameterOf),
+    name: "type_parameter_of",
+    args: TYPE_PARAMETER_OF_ARGS,
+};
+const TYPE_PARAMETER_MAPS_TO: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::TypeParameterMapsTo),
+    name: "type_parameter_maps_to",
+    args: TYPE_PARAMETER_MAPS_TO_ARGS,
+};
+const OWNS_TYPE: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::OwnsType),
+    name: "owns_type",
+    args: OWNS_TYPE_ARGS,
+};
+const IS_SEND_IN: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::IsSendIn),
+    name: "is_send_in",
+    args: IS_SEND_IN_ARGS,
+};
+
+pub fn item_predicate_spec(name: &str) -> Option<&'static ItemPredicateSpec> {
+    match name {
+        "true" => Some(&TRUE),
+        "false" => Some(&FALSE),
+        "has_type_parameters" => Some(&HAS_TYPE_PARAMETERS),
+        "type_parameter_of" => Some(&TYPE_PARAMETER_OF),
+        "type_parameter_maps_to" => Some(&TYPE_PARAMETER_MAPS_TO),
+        "owns_type" => Some(&OWNS_TYPE),
+        "is_send_in" => Some(&IS_SEND_IN),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ItemPredicateArgKind, ItemPredicateArgMode, item_predicate_spec};
+
+    #[test]
+    fn declares_relational_output_modes() {
+        let parameter_of = item_predicate_spec("type_parameter_of").expect("registered predicate");
+        assert_eq!(parameter_of.args.len(), 2);
+        assert_eq!(parameter_of.args[0].mode, ItemPredicateArgMode::Output);
+        assert_eq!(parameter_of.args[0].kind, ItemPredicateArgKind::Type);
+        assert_eq!(parameter_of.args[1].mode, ItemPredicateArgMode::Input);
+        assert_eq!(parameter_of.args[1].kind, ItemPredicateArgKind::Adt);
+
+        let maps_to = item_predicate_spec("type_parameter_maps_to").expect("registered predicate");
+        assert_eq!(maps_to.args.len(), 3);
+        assert_eq!(maps_to.args[1].mode, ItemPredicateArgMode::Output);
+        assert_eq!(maps_to.args[2].kind, ItemPredicateArgKind::Impl);
+    }
+}

--- a/crates/rpl_constraints/src/predicates/item.rs
+++ b/crates/rpl_constraints/src/predicates/item.rs
@@ -6,6 +6,12 @@ pub enum ItemPredicate {
     OwnsType,
     IsSendIn,
     IsSyncIn,
+    /// Emits resource types whose exclusive authority can cross threads through safe operations
+    /// that start from a shared reference to the wrapper.
+    ResourceExclusivelyAccessibleFromSharedRefIn,
+    /// Emits resource types that safe operations starting from a shared reference to the wrapper
+    /// can access concurrently.
+    ResourceConcurrentlyAccessibleFromSharedRefIn,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -76,6 +82,13 @@ const IS_SEND_IN_ARGS: &[ItemPredicateArgSpec] =
     &[ItemPredicateArgSpec::input(Type), ItemPredicateArgSpec::input(Impl)];
 const IS_SYNC_IN_ARGS: &[ItemPredicateArgSpec] =
     &[ItemPredicateArgSpec::input(Type), ItemPredicateArgSpec::input(Impl)];
+const RESOURCE_FROM_SHARED_REF_ARGS: &[ItemPredicateArgSpec] = &[
+    ItemPredicateArgSpec::output(Type),
+    ItemPredicateArgSpec::input(Adt),
+    ItemPredicateArgSpec::input(Type),
+    ItemPredicateArgSpec::input(Type),
+    ItemPredicateArgSpec::input(Impl),
+];
 
 const TRUE: ItemPredicateSpec = ItemPredicateSpec {
     predicate: None,
@@ -117,6 +130,16 @@ const IS_SYNC_IN: ItemPredicateSpec = ItemPredicateSpec {
     name: "is_sync_in",
     args: IS_SYNC_IN_ARGS,
 };
+const RESOURCE_EXCLUSIVELY_ACCESSIBLE_FROM_SHARED_REF_IN: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::ResourceExclusivelyAccessibleFromSharedRefIn),
+    name: "resource_exclusively_accessible_from_shared_ref_in",
+    args: RESOURCE_FROM_SHARED_REF_ARGS,
+};
+const RESOURCE_CONCURRENTLY_ACCESSIBLE_FROM_SHARED_REF_IN: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::ResourceConcurrentlyAccessibleFromSharedRefIn),
+    name: "resource_concurrently_accessible_from_shared_ref_in",
+    args: RESOURCE_FROM_SHARED_REF_ARGS,
+};
 
 pub fn item_predicate_spec(name: &str) -> Option<&'static ItemPredicateSpec> {
     match name {
@@ -128,6 +151,12 @@ pub fn item_predicate_spec(name: &str) -> Option<&'static ItemPredicateSpec> {
         "owns_type" => Some(&OWNS_TYPE),
         "is_send_in" => Some(&IS_SEND_IN),
         "is_sync_in" => Some(&IS_SYNC_IN),
+        "resource_exclusively_accessible_from_shared_ref_in" => {
+            Some(&RESOURCE_EXCLUSIVELY_ACCESSIBLE_FROM_SHARED_REF_IN)
+        },
+        "resource_concurrently_accessible_from_shared_ref_in" => {
+            Some(&RESOURCE_CONCURRENTLY_ACCESSIBLE_FROM_SHARED_REF_IN)
+        },
         _ => None,
     }
 }
@@ -155,5 +184,13 @@ mod tests {
         assert_eq!(is_sync_in.args[0].mode, ItemPredicateArgMode::Input);
         assert_eq!(is_sync_in.args[0].kind, ItemPredicateArgKind::Type);
         assert_eq!(is_sync_in.args[1].kind, ItemPredicateArgKind::Impl);
+
+        let accessible =
+            item_predicate_spec("resource_exclusively_accessible_from_shared_ref_in").expect("registered predicate");
+        assert_eq!(accessible.args.len(), 5);
+        assert_eq!(accessible.args[0].mode, ItemPredicateArgMode::Output);
+        assert_eq!(accessible.args[0].kind, ItemPredicateArgKind::Type);
+        assert_eq!(accessible.args[1].kind, ItemPredicateArgKind::Adt);
+        assert_eq!(accessible.args[4].kind, ItemPredicateArgKind::Impl);
     }
 }

--- a/crates/rpl_constraints/src/predicates/item.rs
+++ b/crates/rpl_constraints/src/predicates/item.rs
@@ -6,11 +6,17 @@ pub enum ItemPredicate {
     OwnsType,
     IsSendIn,
     IsSyncIn,
-    /// Emits resource types whose exclusive authority can cross threads through safe operations
-    /// that start from a shared reference to the wrapper.
+    /// Decides whether the resource satisfies `Send` under the correlated access's applicability
+    /// context and the matched impl substitution.
+    IsSendForAccessIn,
+    /// Decides whether the resource satisfies `Sync` under the correlated access's applicability
+    /// context and the matched impl substitution.
+    IsSyncForAccessIn,
+    /// Emits correlated access witnesses and resource types whose exclusive authority can cross
+    /// threads through safe operations that start from a shared reference to the wrapper.
     ResourceExclusivelyAccessibleFromSharedRefIn,
-    /// Emits resource types that safe operations starting from a shared reference to the wrapper
-    /// can access concurrently.
+    /// Emits correlated access witnesses and resource types that safe operations starting from a
+    /// shared reference to the wrapper can access concurrently.
     ResourceConcurrentlyAccessibleFromSharedRefIn,
 }
 
@@ -25,6 +31,7 @@ pub enum ItemPredicateArgKind {
     Adt,
     Type,
     Impl,
+    Access,
 }
 
 impl ItemPredicateArgKind {
@@ -33,6 +40,7 @@ impl ItemPredicateArgKind {
             Self::Adt => "adt",
             Self::Type => "type",
             Self::Impl => "impl binding",
+            Self::Access => "access",
         }
     }
 }
@@ -66,7 +74,7 @@ pub struct ItemPredicateSpec {
     pub args: &'static [ItemPredicateArgSpec],
 }
 
-use ItemPredicateArgKind::{Adt, Impl, Type};
+use ItemPredicateArgKind::{Access, Adt, Impl, Type};
 
 const NO_ARGS: &[ItemPredicateArgSpec] = &[];
 const ADT_INPUT: &[ItemPredicateArgSpec] = &[ItemPredicateArgSpec::input(Adt)];
@@ -82,7 +90,13 @@ const IS_SEND_IN_ARGS: &[ItemPredicateArgSpec] =
     &[ItemPredicateArgSpec::input(Type), ItemPredicateArgSpec::input(Impl)];
 const IS_SYNC_IN_ARGS: &[ItemPredicateArgSpec] =
     &[ItemPredicateArgSpec::input(Type), ItemPredicateArgSpec::input(Impl)];
+const IS_TRAIT_FOR_ACCESS_IN_ARGS: &[ItemPredicateArgSpec] = &[
+    ItemPredicateArgSpec::input(Type),
+    ItemPredicateArgSpec::input(Access),
+    ItemPredicateArgSpec::input(Impl),
+];
 const RESOURCE_FROM_SHARED_REF_ARGS: &[ItemPredicateArgSpec] = &[
+    ItemPredicateArgSpec::output(Access),
     ItemPredicateArgSpec::output(Type),
     ItemPredicateArgSpec::input(Adt),
     ItemPredicateArgSpec::input(Type),
@@ -130,6 +144,16 @@ const IS_SYNC_IN: ItemPredicateSpec = ItemPredicateSpec {
     name: "is_sync_in",
     args: IS_SYNC_IN_ARGS,
 };
+const IS_SEND_FOR_ACCESS_IN: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::IsSendForAccessIn),
+    name: "is_send_for_access_in",
+    args: IS_TRAIT_FOR_ACCESS_IN_ARGS,
+};
+const IS_SYNC_FOR_ACCESS_IN: ItemPredicateSpec = ItemPredicateSpec {
+    predicate: Some(ItemPredicate::IsSyncForAccessIn),
+    name: "is_sync_for_access_in",
+    args: IS_TRAIT_FOR_ACCESS_IN_ARGS,
+};
 const RESOURCE_EXCLUSIVELY_ACCESSIBLE_FROM_SHARED_REF_IN: ItemPredicateSpec = ItemPredicateSpec {
     predicate: Some(ItemPredicate::ResourceExclusivelyAccessibleFromSharedRefIn),
     name: "resource_exclusively_accessible_from_shared_ref_in",
@@ -151,6 +175,8 @@ pub fn item_predicate_spec(name: &str) -> Option<&'static ItemPredicateSpec> {
         "owns_type" => Some(&OWNS_TYPE),
         "is_send_in" => Some(&IS_SEND_IN),
         "is_sync_in" => Some(&IS_SYNC_IN),
+        "is_send_for_access_in" => Some(&IS_SEND_FOR_ACCESS_IN),
+        "is_sync_for_access_in" => Some(&IS_SYNC_FOR_ACCESS_IN),
         "resource_exclusively_accessible_from_shared_ref_in" => {
             Some(&RESOURCE_EXCLUSIVELY_ACCESSIBLE_FROM_SHARED_REF_IN)
         },
@@ -187,10 +213,16 @@ mod tests {
 
         let accessible =
             item_predicate_spec("resource_exclusively_accessible_from_shared_ref_in").expect("registered predicate");
-        assert_eq!(accessible.args.len(), 5);
+        assert_eq!(accessible.args.len(), 6);
         assert_eq!(accessible.args[0].mode, ItemPredicateArgMode::Output);
-        assert_eq!(accessible.args[0].kind, ItemPredicateArgKind::Type);
-        assert_eq!(accessible.args[1].kind, ItemPredicateArgKind::Adt);
-        assert_eq!(accessible.args[4].kind, ItemPredicateArgKind::Impl);
+        assert_eq!(accessible.args[0].kind, ItemPredicateArgKind::Access);
+        assert_eq!(accessible.args[1].mode, ItemPredicateArgMode::Output);
+        assert_eq!(accessible.args[1].kind, ItemPredicateArgKind::Type);
+        assert_eq!(accessible.args[2].kind, ItemPredicateArgKind::Adt);
+        assert_eq!(accessible.args[5].kind, ItemPredicateArgKind::Impl);
+
+        let access_support = item_predicate_spec("is_sync_for_access_in").expect("registered predicate");
+        assert_eq!(access_support.args.len(), 3);
+        assert_eq!(access_support.args[1].kind, ItemPredicateArgKind::Access);
     }
 }

--- a/crates/rpl_constraints/src/predicates/mod.rs
+++ b/crates/rpl_constraints/src/predicates/mod.rs
@@ -38,6 +38,12 @@ use crate::predicates::item_attr::{ItemAttrPredsFnPtr, has_attr};
 pub enum PredicateError<'i> {
     #[display("Invalid predicate: {pred}\n{span}")]
     InvalidPredicate { pred: &'i str, span: SpanWrapper<'i> },
+    #[display("Predicate `{pred}` is not supported in an item guard\n{span}")]
+    UnsupportedItemGuardPredicate { pred: &'i str, span: SpanWrapper<'i> },
+    #[display("Item guard predicate `{pred}` does not accept arguments\n{span}")]
+    ItemGuardPredicateTakesNoArgs { pred: &'i str, span: SpanWrapper<'i> },
+    #[display("Attributes are not supported in an item guard\n{span}")]
+    UnsupportedItemGuardAttribute { span: SpanWrapper<'i> },
     #[display("Invalid predicate argument: {_0}")]
     InvalidArgs(String),
 }
@@ -212,6 +218,7 @@ impl PredicateClause {
 
 #[derive(Clone, Debug)]
 pub struct PredicateTerm {
+    pub name: String,
     pub kind: PredicateKind,
     pub args: Vec<PredicateArg>,
     pub is_neg: bool,
@@ -224,6 +231,7 @@ impl PredicateTerm {
             Choice2::_1(pred) => (pred.get_matched().1, true),
         };
         let (pred_name, _, args, _) = pred.get_matched();
+        let name = pred_name.span.as_str().to_string();
         let kind = PredicateKind::try_from(SpanWrapper::new(pred_name.span, path))?;
         let args = if let Some(args) = args {
             let (first, following, _) = args.get_matched();
@@ -237,7 +245,12 @@ impl PredicateTerm {
         } else {
             vec![]
         };
-        Ok(Self { kind, is_neg, args })
+        Ok(Self {
+            name,
+            kind,
+            is_neg,
+            args,
+        })
     }
 }
 

--- a/crates/rpl_constraints/src/predicates/mod.rs
+++ b/crates/rpl_constraints/src/predicates/mod.rs
@@ -123,6 +123,8 @@ pub const ALL_PREDICATES: &[&str] = &[
     // single_fn_preds
     "requires_monomorphization",
     "runs_outside_main",
+    // item_attr_preds
+    "has_attr",
     // ty_const_preds
     "maybe_misaligned",
     // single_const_preds

--- a/crates/rpl_constraints/src/predicates/mod.rs
+++ b/crates/rpl_constraints/src/predicates/mod.rs
@@ -106,6 +106,8 @@ pub const ALL_PREDICATES: &[&str] = &[
     "owns_type",
     "is_send_in",
     "is_sync_in",
+    "resource_exclusively_accessible_from_shared_ref_in",
+    "resource_concurrently_accessible_from_shared_ref_in",
     // translate_preds
     "translate_from_function",
     // trivial_preds
@@ -202,6 +204,12 @@ impl<'i> TryFrom<SpanWrapper<'i>> for PredicateKind {
             "owns_type" => Self::Item(ItemPredicate::OwnsType),
             "is_send_in" => Self::Item(ItemPredicate::IsSendIn),
             "is_sync_in" => Self::Item(ItemPredicate::IsSyncIn),
+            "resource_exclusively_accessible_from_shared_ref_in" => {
+                Self::Item(ItemPredicate::ResourceExclusivelyAccessibleFromSharedRefIn)
+            },
+            "resource_concurrently_accessible_from_shared_ref_in" => {
+                Self::Item(ItemPredicate::ResourceConcurrentlyAccessibleFromSharedRefIn)
+            },
             _ => {
                 return Err(PredicateError::InvalidPredicate {
                     pred: span.inner().as_str(),

--- a/crates/rpl_constraints/src/predicates/mod.rs
+++ b/crates/rpl_constraints/src/predicates/mod.rs
@@ -106,6 +106,8 @@ pub const ALL_PREDICATES: &[&str] = &[
     "owns_type",
     "is_send_in",
     "is_sync_in",
+    "is_send_for_access_in",
+    "is_sync_for_access_in",
     "resource_exclusively_accessible_from_shared_ref_in",
     "resource_concurrently_accessible_from_shared_ref_in",
     // translate_preds
@@ -204,6 +206,8 @@ impl<'i> TryFrom<SpanWrapper<'i>> for PredicateKind {
             "owns_type" => Self::Item(ItemPredicate::OwnsType),
             "is_send_in" => Self::Item(ItemPredicate::IsSendIn),
             "is_sync_in" => Self::Item(ItemPredicate::IsSyncIn),
+            "is_send_for_access_in" => Self::Item(ItemPredicate::IsSendForAccessIn),
+            "is_sync_for_access_in" => Self::Item(ItemPredicate::IsSyncForAccessIn),
             "resource_exclusively_accessible_from_shared_ref_in" => {
                 Self::Item(ItemPredicate::ResourceExclusivelyAccessibleFromSharedRefIn)
             },

--- a/crates/rpl_constraints/src/predicates/mod.rs
+++ b/crates/rpl_constraints/src/predicates/mod.rs
@@ -8,6 +8,7 @@ use rustc_span::Symbol;
 // Attention:
 // When you add a new module here,
 // Try to keep all predicate signatures consistent in it.
+mod item;
 mod item_attr;
 mod locals;
 mod multiple_consts;
@@ -20,6 +21,7 @@ mod translate;
 mod trivial;
 mod ty_const;
 
+pub use item::*;
 pub use locals::*;
 pub use multiple_consts::*;
 pub use multiple_tys::*;
@@ -40,8 +42,36 @@ pub enum PredicateError<'i> {
     InvalidPredicate { pred: &'i str, span: SpanWrapper<'i> },
     #[display("Predicate `{pred}` is not supported in an item guard\n{span}")]
     UnsupportedItemGuardPredicate { pred: &'i str, span: SpanWrapper<'i> },
+    #[display("Predicate `{pred}` is only supported in an item guard\n{span}")]
+    ItemPredicateOutsideItemGuard { pred: &'i str, span: SpanWrapper<'i> },
     #[display("Item guard predicate `{pred}` does not accept arguments\n{span}")]
     ItemGuardPredicateTakesNoArgs { pred: &'i str, span: SpanWrapper<'i> },
+    #[display("Item guard predicate `{pred}` expects {expected} arguments, but received {actual}\n{span}")]
+    InvalidItemGuardArity {
+        pred: &'i str,
+        expected: usize,
+        actual: usize,
+        span: SpanWrapper<'i>,
+    },
+    #[display("Argument `{arg}` of item guard predicate `{pred}` must be a {expected}\n{span}")]
+    InvalidItemGuardArgument {
+        pred: &'i str,
+        arg: &'i str,
+        expected: &'static str,
+        span: SpanWrapper<'i>,
+    },
+    #[display(
+        "Input `{arg}` of item guard predicate `{pred}` is not bound; reorder the predicates so its producer runs first\n{span}"
+    )]
+    UnboundItemGuardInput {
+        pred: &'i str,
+        arg: &'i str,
+        span: SpanWrapper<'i>,
+    },
+    #[display("Output-producing item guard predicate `{pred}` cannot be negated\n{span}")]
+    NegatedItemGuardOutput { pred: &'i str, span: SpanWrapper<'i> },
+    #[display("Output-producing item guard predicate `{pred}` is not supported inside a disjunction\n{span}")]
+    ItemGuardOutputInDisjunction { pred: &'i str, span: SpanWrapper<'i> },
     #[display("Attributes are not supported in an item guard\n{span}")]
     UnsupportedItemGuardAttribute { span: SpanWrapper<'i> },
     #[display("Invalid predicate argument: {_0}")]
@@ -69,6 +99,12 @@ pub const ALL_PREDICATES: &[&str] = &[
     "is_ref",
     "is_zst",
     "needs_drop",
+    // item predicates
+    "has_type_parameters",
+    "type_parameter_of",
+    "type_parameter_maps_to",
+    "owns_type",
+    "is_send_in",
     // translate_preds
     "translate_from_function",
     // trivial_preds
@@ -118,6 +154,7 @@ pub enum PredicateKind {
     FlowsTo,
     /// `may_panic('sink)` — potential panic site; evaluated in matcher.
     MayPanic,
+    Item(ItemPredicate),
 }
 
 impl<'i> TryFrom<SpanWrapper<'i>> for PredicateKind {
@@ -158,6 +195,11 @@ impl<'i> TryFrom<SpanWrapper<'i>> for PredicateKind {
             "has_attr" => Self::ItemAttr(has_attr),
             "flows_to" => Self::FlowsTo,
             "may_panic" => Self::MayPanic,
+            "has_type_parameters" => Self::Item(ItemPredicate::HasTypeParameters),
+            "type_parameter_of" => Self::Item(ItemPredicate::TypeParameterOf),
+            "type_parameter_maps_to" => Self::Item(ItemPredicate::TypeParameterMapsTo),
+            "owns_type" => Self::Item(ItemPredicate::OwnsType),
+            "is_send_in" => Self::Item(ItemPredicate::IsSendIn),
             _ => {
                 return Err(PredicateError::InvalidPredicate {
                     pred: span.inner().as_str(),

--- a/crates/rpl_constraints/src/predicates/mod.rs
+++ b/crates/rpl_constraints/src/predicates/mod.rs
@@ -105,6 +105,7 @@ pub const ALL_PREDICATES: &[&str] = &[
     "type_parameter_maps_to",
     "owns_type",
     "is_send_in",
+    "is_sync_in",
     // translate_preds
     "translate_from_function",
     // trivial_preds
@@ -200,6 +201,7 @@ impl<'i> TryFrom<SpanWrapper<'i>> for PredicateKind {
             "type_parameter_maps_to" => Self::Item(ItemPredicate::TypeParameterMapsTo),
             "owns_type" => Self::Item(ItemPredicate::OwnsType),
             "is_send_in" => Self::Item(ItemPredicate::IsSendIn),
+            "is_sync_in" => Self::Item(ItemPredicate::IsSyncIn),
             _ => {
                 return Err(PredicateError::InvalidPredicate {
                     pred: span.inner().as_str(),

--- a/crates/rpl_context/src/pat/error.rs
+++ b/crates/rpl_context/src/pat/error.rs
@@ -9,7 +9,7 @@
 // )]
 
 use derive_more::{Debug, Display};
-use rpl_meta::symbol_table::{DiagSymbolTable, MetaVariableType, NonLocalMetaSymTab, WithPath};
+use rpl_meta::symbol_table::{DiagSymbolTable, MetaVariable, MetaVariableType, NonLocalMetaSymTab, WithPath};
 use rpl_meta::{DYNAMIC, collect_elems_separated_by_comma};
 use rpl_parser::generics::Choice2;
 use rpl_parser::pairs::diagMessageInner;
@@ -279,15 +279,19 @@ impl<'i> SubMsg<'i> {
                     } else if labels.contains(&name) {
                         msgs.push(SubMsg::Label(name))
                     } else {
-                        let (var_type, idx, _) = meta_vars
-                            .get_meta_var_from_name(meta_var)
-                            .unwrap_or_else(|| {
-                                panic!(
-                                    "Meta variable `{}` not found:\n    non-local meta symbol table {:?}\n    labels: {:?}",
-                                    meta_var, meta_vars, labels
-                                )
-                            })
-                            .expect_non_adt();
+                        let meta_var = meta_vars.get_meta_var_from_name(meta_var).unwrap_or_else(|| {
+                            panic!(
+                                "Meta variable `{}` not found:\n    non-local meta symbol table {:?}\n    labels: {:?}",
+                                meta_var, meta_vars, labels
+                            )
+                        });
+                        if matches!(meta_var, MetaVariable::Access(..)) {
+                            panic!(
+                                "Unexpected access meta variable in diagnostic message: {}",
+                                arg.span.as_str()
+                            );
+                        }
+                        let (var_type, idx, _) = meta_var.expect_non_adt();
                         match var_type {
                             MetaVariableType::Type => msgs.push(SubMsg::Ty(idx.into())),
                             MetaVariableType::Const => msgs.push(SubMsg::Const(idx.into())),
@@ -295,6 +299,7 @@ impl<'i> SubMsg<'i> {
                                 "Unexpected place meta variable in diagnostic message: {}",
                                 arg.span.as_str()
                             ),
+                            MetaVariableType::Access => unreachable!("access handled before indexed metavariables"),
                         }
                     }
                 },

--- a/crates/rpl_context/src/pat/item.rs
+++ b/crates/rpl_context/src/pat/item.rs
@@ -26,9 +26,22 @@ pub type Struct<'pcx> = WithMetaTable<'pcx, StructInner<'pcx>>;
 pub type EnumInner<'pcx> = FxIndexMap<Symbol, Variant<'pcx>>;
 pub type Enum<'pcx> = WithMetaTable<'pcx, EnumInner<'pcx>>;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RestPat {
+    #[default]
+    Exact,
+    Rest,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ItemGenericsPat {
+    pub rest: RestPat,
+}
+
 #[derive(Debug)]
 pub struct Adt<'pcx> {
     pub meta: Arc<NonLocalMetaVars<'pcx>>,
+    pub generics: ItemGenericsPat,
     pub kind: AdtKind<'pcx>,
     pub constraints: Constraints,
 }
@@ -37,10 +50,12 @@ impl<'pcx> Adt<'pcx> {
     pub(crate) fn new_struct(
         inner: StructInner<'pcx>,
         meta: Arc<NonLocalMetaVars<'pcx>>,
+        generics: ItemGenericsPat,
         constraints: Constraints,
     ) -> Self {
         Self {
             meta,
+            generics,
             kind: AdtKind::Struct(inner),
             constraints,
         }
@@ -52,6 +67,7 @@ impl<'pcx> Adt<'pcx> {
     ) -> Self {
         Self {
             meta,
+            generics: ItemGenericsPat::default(),
             kind: AdtKind::Enum(inner),
             constraints,
         }
@@ -108,6 +124,7 @@ pub enum AdtKind<'pcx> {
 #[derive(Default, Debug)]
 pub struct Variant<'pcx> {
     pub fields: FxIndexMap<Symbol, Field<'pcx>>,
+    pub rest: RestPat,
 }
 
 impl<'pcx> Variant<'pcx> {
@@ -134,10 +151,33 @@ pub struct Field<'pcx> {
     pub ty: Ty<'pcx>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct ImplSelfTy<'pcx> {
+    pub ty: Ty<'pcx>,
+    pub generic_args: RestPat,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SafetyPat {
+    Safe,
+    Unsafe,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImplPolarityPat {
+    Positive,
+}
+
+#[derive(Debug)]
 pub struct Impl<'pcx> {
+    pub binding: Option<Symbol>,
+    pub safety: SafetyPat,
+    pub polarity: ImplPolarityPat,
+    pub generics: ItemGenericsPat,
     pub meta: Arc<NonLocalMetaVars<'pcx>>,
-    pub(crate) ty: Ty<'pcx>,
-    pub(crate) trait_id: Option<Path<'pcx>>,
+    pub self_ty: ImplSelfTy<'pcx>,
+    pub trait_path: Option<Path<'pcx>>,
+    pub where_clause: RestPat,
     pub fns: FxHashMap<Symbol, FnPattern<'pcx>>,
     pub constraints: Constraints,
 }

--- a/crates/rpl_context/src/pat/mod.rs
+++ b/crates/rpl_context/src/pat/mod.rs
@@ -105,7 +105,7 @@ impl<'pcx> PatternItem<'pcx> {
                         map.extend(body.labels.iter().map(|(&k, &v)| (k, v)));
                     }
                 }
-                for impl_pat in items.impls.values() {
+                for impl_pat in &items.impls {
                     for fn_pat in impl_pat.fns.values() {
                         if let Some(body) = fn_pat.body {
                             map.extend(body.labels.iter().map(|(&k, &v)| (k, v)));
@@ -133,18 +133,25 @@ pub struct RustItems<'pcx> {
     pub meta: Arc<NonLocalMetaVars<'pcx>>,
     pub adts: FxHashMap<Symbol, Adt<'pcx>>,
     pub fns: FnPatterns<'pcx>,
-    pub impls: FxHashMap<Symbol, Impl<'pcx>>,
+    pub impls: Vec<Impl<'pcx>>,
+    pub item_constraints: Option<Constraints>,
     pub attr: PatAttr<'pcx>,
 }
 
 impl<'pcx> RustItems<'pcx> {
-    pub(crate) fn new(pcx: PatCtxt<'pcx>, meta: Arc<NonLocalMetaVars<'pcx>>, attr: PatAttr<'pcx>) -> Self {
+    pub(crate) fn new(
+        pcx: PatCtxt<'pcx>,
+        meta: Arc<NonLocalMetaVars<'pcx>>,
+        item_constraints: Option<Constraints>,
+        attr: PatAttr<'pcx>,
+    ) -> Self {
         Self {
             pcx,
             meta,
             adts: Default::default(),
             fns: Default::default(),
             impls: Default::default(),
+            item_constraints,
             attr,
         }
     }
@@ -212,9 +219,22 @@ impl<'pcx> RustItems<'pcx> {
         constraints: Constraints,
     ) {
         let mut struct_inner = StructInner::default();
-        let name = rust_struct.MetaVariable();
-        if let Some(fields) = rust_struct.get_matched().4 {
-            let fields = collect_elems_separated_by_comma!(fields);
+        let (_, _, name, generic_wildcard, _, fields, _) = rust_struct.get_matched();
+        if let Some(fields) = fields {
+            let (fields, rest): (Vec<_>, RestPat) = if let Some(fields) = fields.NonExhaustiveFields() {
+                (fields.Field(), RestPat::Rest)
+            } else {
+                (
+                    collect_elems_separated_by_comma!(
+                        fields
+                            .FieldsSeparatedByComma()
+                            .expect("StructFields must contain one alternative")
+                    )
+                    .collect(),
+                    RestPat::Exact,
+                )
+            };
+            struct_inner.rest = rest;
             for field in fields {
                 let (name, _, ty) = field.get_matched();
                 let name = Symbol::intern(name.span.as_str());
@@ -224,7 +244,18 @@ impl<'pcx> RustItems<'pcx> {
             }
         }
 
-        let struct_pat = Adt::new_struct(struct_inner, meta, constraints);
+        let struct_pat = Adt::new_struct(
+            struct_inner,
+            meta,
+            ItemGenericsPat {
+                rest: if generic_wildcard.is_some() {
+                    RestPat::Rest
+                } else {
+                    RestPat::Exact
+                },
+            },
+            constraints,
+        );
         // let struct_pat = self.pcx.alloc_struct(struct_pat);
         self.adts.insert(Symbol::intern(name.span.as_str()), struct_pat);
     }
@@ -282,19 +313,35 @@ impl<'pcx> RustItems<'pcx> {
     #[instrument(level = "debug", skip(self, rust_impl, meta, symbol_table))]
     fn add_impl<'mcx: 'pcx>(
         &mut self,
-        pat_name: Option<Symbol>,
+        _pat_name: Option<Symbol>,
         rust_impl: WithPath<'pcx, &'pcx pairs::Impl<'pcx>>,
         meta: Arc<NonLocalMetaVars<'pcx>>,
         symbol_table: &'mcx rpl_meta::symbol_table::SymbolTable<'mcx>,
         constraints: Constraints,
     ) {
         let p = rust_impl.path;
-        let (_, _, impl_kind, ty, _, fns, _) = rust_impl.get_matched();
-        let impl_sym_tab = symbol_table.get_impl(ty, impl_kind.as_ref()).unwrap();
-        let ty = Ty::from(WithPath::new(p, ty), self.pcx, symbol_table);
-        let trait_id = impl_kind
-            .as_ref()
-            .map(|impl_kind| Path::from_pairs(impl_kind.get_matched().0, self.pcx));
+        let (binding, unsafety, _, generics, impl_kind, self_ty, where_clause, _, fns, _) = rust_impl.get_matched();
+        let impl_sym_tab = symbol_table.get_impl(self_ty, impl_kind.as_ref()).unwrap();
+        let self_ty = if let Some(adt_ty) = self_ty.ItemAdtType() {
+            ImplSelfTy {
+                ty: self
+                    .pcx
+                    .mk_adt_pat_ty(Symbol::intern(adt_ty.MetaVariable().span.as_str())),
+                generic_args: RestPat::Rest,
+            }
+        } else {
+            ImplSelfTy {
+                ty: Ty::from(
+                    WithPath::new(p, self_ty.Type().expect("ImplSelfType must contain one alternative")),
+                    self.pcx,
+                    symbol_table,
+                ),
+                generic_args: RestPat::Exact,
+            }
+        };
+        let trait_path = impl_kind.as_ref().map(|impl_kind| {
+            Path::from_imported_pairs(WithPath::new(p, impl_kind.get_matched().0), self.pcx, symbol_table)
+        });
         let fns = fns
             .iter_matched()
             .map(|rust_fn| {
@@ -315,16 +362,39 @@ impl<'pcx> RustItems<'pcx> {
             })
             .collect();
         let impl_pat = Impl {
+            binding: binding
+                .as_ref()
+                .map(|binding| Symbol::intern(binding.MetaVariable().span.as_str())),
+            safety: if unsafety.is_some() {
+                SafetyPat::Unsafe
+            } else {
+                SafetyPat::Safe
+            },
+            polarity: ImplPolarityPat::Positive,
+            generics: ItemGenericsPat {
+                rest: if generics.is_some() {
+                    RestPat::Rest
+                } else {
+                    RestPat::Exact
+                },
+            },
             meta,
-            ty,
-            trait_id,
+            self_ty,
+            trait_path,
+            where_clause: if where_clause.is_some() {
+                RestPat::Rest
+            } else {
+                RestPat::Exact
+            },
             fns,
             constraints,
         };
-        debug!(ty = ?impl_pat.ty, trait_id = ?impl_pat.trait_id, fns = ?impl_pat.fns.keys());
-        if let Some(pat_name) = pat_name {
-            self.impls.insert(pat_name, impl_pat);
-        }
+        debug!(
+            ty = ?impl_pat.self_ty,
+            trait_path = ?impl_pat.trait_path,
+            fns = ?impl_pat.fns.keys()
+        );
+        self.impls.push(impl_pat);
     }
 
     #[instrument(level = "trace", skip(self), fields(adts = ?self.adts.keys()), ret)]
@@ -332,14 +402,26 @@ impl<'pcx> RustItems<'pcx> {
         self.adts.get(&adt)
     }
 
+    /// Compatibility bridge for the function-rooted matcher.
+    ///
+    /// Preserve the old effective last-impl-wins behavior for function-rooted
+    /// matching while retaining every impl in [`Self::impls`] for item matching.
+    pub fn legacy_impl_for_function_matching(&self) -> Option<&Impl<'pcx>> {
+        self.legacy_function_matching_enabled()
+            .then(|| self.impls.last())
+            .flatten()
+    }
+
+    /// Item constraints may refer to ADT and impl bindings, which the
+    /// function-rooted matcher cannot represent.
+    pub fn legacy_function_matching_enabled(&self) -> bool {
+        self.item_constraints.is_none()
+    }
+
     fn table_head(&self) -> TableHead {
         let mut columns = FxHashMap::default();
 
         self.meta.table_head(&mut columns);
-
-        for name in self.adts.keys() {
-            columns.try_insert(*name, ColumnType::Ty).unwrap();
-        }
 
         // FIX: should self.attr be included in the table head?
 
@@ -474,16 +556,23 @@ impl<'pcx> Pattern<'pcx> {
                     with_path(p, std::iter::once(item)),
                     symbol_table,
                     meta,
+                    None,
                     block_type,
                 );
             },
             Choice3::_1(items) => {
+                let (_, rust_items, _, where_block) = items.get_matched();
+                let item_constraints = where_block.as_ref().map(|_| {
+                    Constraints::from_where_block_opt(std::iter::empty(), where_block, p)
+                        .unwrap_or_else(|err| panic!("unexpected error in pattern constraints:\n{err}"))
+                });
                 self.add_items(
                     pat_name,
                     attr,
-                    with_path(p, items.get_matched().1.iter_matched()),
+                    with_path(p, rust_items.iter_matched()),
                     symbol_table,
                     meta,
+                    item_constraints,
                     block_type,
                 );
             },
@@ -550,6 +639,7 @@ impl<'pcx> Pattern<'pcx> {
         .table_head();
     }
 
+    #[expect(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip(self, attr, items, symbol_table, meta))]
     fn add_items(
         &mut self,
@@ -558,6 +648,7 @@ impl<'pcx> Pattern<'pcx> {
         items: WithPath<'pcx, impl Iterator<Item = &'pcx pairs::RustItemWithConstraint<'pcx>>>,
         symbol_table: &'pcx rpl_meta::symbol_table::SymbolTable<'_>,
         meta: Arc<NonLocalMetaVars<'pcx>>,
+        item_constraints: Option<Constraints>,
         block_type: PattOrUtil,
     ) {
         let p = items.path;
@@ -565,7 +656,7 @@ impl<'pcx> Pattern<'pcx> {
             PattOrUtil::Patt => {
                 self.patt_block.entry(pat_name).or_insert_with(|| {
                     let attr = PatAttr::parse_all(attr);
-                    let mut rpl_rust_items = RustItems::new(self.pcx, meta.clone(), attr);
+                    let mut rpl_rust_items = RustItems::new(self.pcx, meta.clone(), item_constraints, attr);
                     for item in items.inner {
                         rpl_rust_items.add_item(Some(pat_name), with_path(p, item), meta.clone(), symbol_table);
                     }
@@ -575,7 +666,7 @@ impl<'pcx> Pattern<'pcx> {
             PattOrUtil::Util => {
                 self.util_block.entry(pat_name).or_insert_with(|| {
                     let attr = PatAttr::parse_all(attr);
-                    let mut rpl_rust_items = RustItems::new(self.pcx, meta.clone(), attr);
+                    let mut rpl_rust_items = RustItems::new(self.pcx, meta.clone(), item_constraints, attr);
                     for item in items.inner {
                         rpl_rust_items.add_item(Some(pat_name), with_path(p, item), meta.clone(), symbol_table);
                     }

--- a/crates/rpl_context/src/pat/mod.rs
+++ b/crates/rpl_context/src/pat/mod.rs
@@ -510,6 +510,370 @@ impl<'pcx> Pattern<'pcx> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pest_typed::ParsableTypedNode as _;
+    use rpl_meta::arena::Arena;
+    use rpl_meta::context::MetaContext;
+    use rpl_meta::symbol_table::SymbolTable;
+    use rpl_parser::pairs;
+    use rustc_span::Symbol;
+
+    use super::{ImplPolarityPat, Path as PatPath, PattOrUtil, RestPat, SafetyPat, WithPath};
+    use crate::PatternCtxt;
+
+    fn item_meta_errors(source: &str, import_sources: &[&str]) -> Vec<String> {
+        let arena = &*Box::leak(Box::new(Arena::default()));
+        let mctx = &*Box::leak(Box::new(MetaContext::new(arena)));
+        let source = arena.alloc_str(source);
+        let item = &*Box::leak(Box::new(
+            pairs::RPLPatternItem::try_parse(source).expect("parse item pattern"),
+        ));
+        let imports: Vec<_> = import_sources
+            .iter()
+            .map(|source| {
+                &*Box::leak(Box::new(
+                    pairs::UsePath::try_parse(arena.alloc_str(source)).expect("parse import"),
+                ))
+            })
+            .collect();
+        let path = Path::new("/synthetic/item-pattern.rpl");
+        mctx.set_active_path(Some(path));
+        let mut errors = Vec::new();
+
+        SymbolTable::collect_symbol_tables(mctx, &imports, std::iter::once(item), &mut errors);
+        errors.into_iter().map(|error| error.to_string()).collect()
+    }
+
+    #[test]
+    fn lowers_item_pattern_syntax_flags() {
+        let arena = &*Box::leak(Box::new(Arena::default()));
+        let mctx = &*Box::leak(Box::new(MetaContext::new(arena)));
+        let source = arena.alloc_str(
+            r#"
+send_variance[
+    $Wrapper: adt where true(),
+    $Parameter: type,
+    $MappedType: type,
+] = {
+    struct $Wrapper<..> { .. }
+
+    $send_impl:
+    unsafe impl<..> Send for $Wrapper<..>
+    where ..
+    {}
+
+    $sync_impl:
+    unsafe impl<..> Sync for $Wrapper<..>
+    where ..
+    {}
+} where {
+    true()
+}
+"#,
+        );
+        let item = &*Box::leak(Box::new(
+            pairs::RPLPatternItem::try_parse(source).expect("parse item pattern"),
+        ));
+        let path = Path::new("/synthetic/item-pattern.rpl");
+        mctx.set_active_path(Some(path));
+        let send_import = &*Box::leak(Box::new(
+            pairs::UsePath::try_parse(arena.alloc_str("use core::marker::Send;")).expect("parse Send import"),
+        ));
+        let sync_import = &*Box::leak(Box::new(
+            pairs::UsePath::try_parse(arena.alloc_str("use core::marker::Sync;")).expect("parse Sync import"),
+        ));
+        let imports = [send_import, sync_import];
+
+        let mut errors = Vec::new();
+        let symbol_tables = SymbolTable::collect_symbol_tables(mctx, &imports, std::iter::once(item), &mut errors);
+        assert!(errors.is_empty(), "meta errors: {errors:#?}");
+        let symbol_tables = &*Box::leak(Box::new(symbol_tables));
+
+        PatternCtxt::entered_no_tcx(|pcx| {
+            let pattern = pcx.new_pattern();
+            pattern.add_pattern_item(WithPath::new(path, item), symbol_tables, PattOrUtil::Patt);
+
+            let rust_items = pattern
+                .patt_block
+                .values()
+                .next()
+                .expect("lowered pattern item")
+                .expect_rust_items();
+            assert_eq!(rust_items.adts.len(), 1);
+            assert_eq!(rust_items.impls.len(), 2, "impl patterns must not overwrite each other");
+            assert_eq!(
+                rust_items
+                    .item_constraints
+                    .as_ref()
+                    .expect("item constraints")
+                    .preds
+                    .len(),
+                1
+            );
+            assert_eq!(rust_items.meta.adt_vars.len(), 1);
+            assert_eq!(
+                rust_items
+                    .meta
+                    .adt_vars
+                    .iter()
+                    .next()
+                    .expect("ADT variable")
+                    .pred
+                    .clauses
+                    .len(),
+                1
+            );
+
+            let adt = rust_items.adts.values().next().expect("struct pattern");
+            assert_eq!(adt.generics.rest, RestPat::Rest);
+            assert_eq!(adt.non_enum_variant().rest, RestPat::Rest);
+
+            let send_impl = &rust_items.impls[0];
+            assert_eq!(send_impl.binding.expect("impl binding").as_str(), "$send_impl");
+            assert_eq!(send_impl.safety, SafetyPat::Unsafe);
+            assert_eq!(send_impl.polarity, ImplPolarityPat::Positive);
+            assert_eq!(send_impl.generics.rest, RestPat::Rest);
+            assert_eq!(send_impl.self_ty.generic_args, RestPat::Rest);
+            assert_eq!(send_impl.where_clause, RestPat::Rest);
+            let PatPath::Item(send_path) = send_impl.trait_path.expect("Send trait path") else {
+                panic!("Send should lower as an item path")
+            };
+            assert_eq!(
+                send_path.0,
+                &[Symbol::intern("core"), Symbol::intern("marker"), Symbol::intern("Send")]
+            );
+
+            let sync_impl = &rust_items.impls[1];
+            assert_eq!(sync_impl.binding.expect("impl binding").as_str(), "$sync_impl");
+            assert_eq!(sync_impl.safety, SafetyPat::Unsafe);
+            let PatPath::Item(sync_path) = sync_impl.trait_path.expect("Sync trait path") else {
+                panic!("Sync should lower as an item path")
+            };
+            assert_eq!(
+                sync_path.0,
+                &[Symbol::intern("core"), Symbol::intern("marker"), Symbol::intern("Sync")]
+            );
+            assert!(
+                !rust_items.legacy_function_matching_enabled(),
+                "item-guarded bundles must wait for the item matcher"
+            );
+            assert!(rust_items.legacy_impl_for_function_matching().is_none());
+        });
+    }
+
+    #[test]
+    fn rejects_unimported_bare_impl_trait_path() {
+        let errors = item_meta_errors(
+            r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+    $marker: unsafe impl<..> Send for $Wrapper<..> {}
+}
+"#,
+            &[],
+        );
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("Impl trait path `Send` is unqualified")),
+            "expected unimported-trait-path error, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_impl_trait_path_imports_and_arguments() {
+        let pattern = r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+    $marker: unsafe impl<..> Send for $Wrapper<..> {}
+}
+"#;
+        let errors = item_meta_errors(pattern, &["use Send;"]);
+        assert!(
+            errors.iter().any(|error| error.contains("Cyclic imports")),
+            "expected self-import cycle error, got: {errors:#?}"
+        );
+
+        let recursive_pattern = r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+    $marker: unsafe impl<..> A for $Wrapper<..> {}
+}
+"#;
+        let errors = item_meta_errors(recursive_pattern, &["use B::A;", "use A::B;"]);
+        assert!(
+            errors.iter().any(|error| error.contains("Cyclic imports")),
+            "expected recursive-import cycle error, got: {errors:#?}"
+        );
+
+        let generic_pattern = r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+    $marker: unsafe impl<..> Send<u8> for $Wrapper<..> {}
+}
+"#;
+        let errors = item_meta_errors(generic_pattern, &["use core::marker::Send;"]);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("Generic arguments in impl trait paths are not supported")),
+            "expected generic-argument error, got: {errors:#?}"
+        );
+        let errors = item_meta_errors(pattern, &["use core::marker::Send<u8>;"]);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("Generic arguments in impl trait paths are not supported")),
+            "expected imported generic-argument error, got: {errors:#?}"
+        );
+
+        let absolute_bare_pattern = r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+    $marker: unsafe impl<..> ::Send for $Wrapper<..> {}
+}
+"#;
+        let errors = item_meta_errors(absolute_bare_pattern, &[]);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("Impl trait path `::Send` is unqualified")),
+            "expected absolute-bare-path error, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_impl_bindings() {
+        let arena = &*Box::leak(Box::new(Arena::default()));
+        let mctx = &*Box::leak(Box::new(MetaContext::new(arena)));
+        let source = arena.alloc_str(
+            r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+    $marker: unsafe impl<..> core::marker::Send for $Wrapper<..> {}
+    $marker: unsafe impl<..> core::marker::Sync for $Wrapper<..> {}
+}
+"#,
+        );
+        let item = &*Box::leak(Box::new(
+            pairs::RPLPatternItem::try_parse(source).expect("parse item pattern"),
+        ));
+        let path = Path::new("/synthetic/duplicate-item-binding.rpl");
+        mctx.set_active_path(Some(path));
+        let mut errors = Vec::new();
+
+        SymbolTable::collect_symbol_tables(mctx, &[], std::iter::once(item), &mut errors);
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.to_string().contains("Symbol `$marker` is already declared")),
+            "expected duplicate item-binding error, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn validates_bundle_predicates_during_meta_checking() {
+        let arena = &*Box::leak(Box::new(Arena::default()));
+        let mctx = &*Box::leak(Box::new(MetaContext::new(arena)));
+        let source = arena.alloc_str(
+            r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+} where {
+    not_a_predicate()
+}
+"#,
+        );
+        let item = &*Box::leak(Box::new(
+            pairs::RPLPatternItem::try_parse(source).expect("parse item pattern"),
+        ));
+        let path = Path::new("/synthetic/invalid-bundle-predicate.rpl");
+        mctx.set_active_path(Some(path));
+        let mut errors = Vec::new();
+
+        SymbolTable::collect_symbol_tables(mctx, &[], std::iter::once(item), &mut errors);
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.to_string().contains("Invalid predicate: not_a_predicate")),
+            "expected invalid-predicate error, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn rejects_predicates_other_than_true_and_false_in_item_guards() {
+        let arena = &*Box::leak(Box::new(Arena::default()));
+        let mctx = &*Box::leak(Box::new(MetaContext::new(arena)));
+        let source = arena.alloc_str(
+            r#"
+p[$Wrapper: adt, $T: type] = {
+    struct $Wrapper<..> { .. }
+} where {
+    is_send($T)
+}
+"#,
+        );
+        let item = &*Box::leak(Box::new(
+            pairs::RPLPatternItem::try_parse(source).expect("parse item pattern"),
+        ));
+        let path = Path::new("/synthetic/unsupported-item-predicate.rpl");
+        mctx.set_active_path(Some(path));
+        let mut errors = Vec::new();
+
+        SymbolTable::collect_symbol_tables(mctx, &[], std::iter::once(item), &mut errors);
+
+        assert!(
+            errors.iter().any(|error| error
+                .to_string()
+                .contains("Predicate `is_send` is not supported in an item guard")),
+            "expected unsupported-item-predicate error, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn rejects_arguments_and_attributes_in_item_guards() {
+        let arena = &*Box::leak(Box::new(Arena::default()));
+        let mctx = &*Box::leak(Box::new(MetaContext::new(arena)));
+        let source = arena.alloc_str(
+            r#"
+p[$Wrapper: adt] = {
+    struct $Wrapper<..> { .. }
+} where {
+    true($Wrapper),
+    safety = safe
+}
+"#,
+        );
+        let item = &*Box::leak(Box::new(
+            pairs::RPLPatternItem::try_parse(source).expect("parse item pattern"),
+        ));
+        let path = Path::new("/synthetic/invalid-item-guard.rpl");
+        mctx.set_active_path(Some(path));
+        let mut errors = Vec::new();
+
+        SymbolTable::collect_symbol_tables(mctx, &[], std::iter::once(item), &mut errors);
+
+        assert!(
+            errors.iter().any(|error| error
+                .to_string()
+                .contains("Item guard predicate `true` does not accept arguments")),
+            "expected item-predicate-arguments error, got: {errors:#?}"
+        );
+        assert!(
+            errors.iter().any(|error| error
+                .to_string()
+                .contains("Attributes are not supported in an item guard")),
+            "expected unsupported-item-attribute error, got: {errors:#?}"
+        );
+    }
+}
+
 impl<'pcx> Pattern<'pcx> {
     pub fn add_pattern_item(
         &mut self,

--- a/crates/rpl_context/src/pat/mod.rs
+++ b/crates/rpl_context/src/pat/mod.rs
@@ -547,6 +547,18 @@ mod tests {
         errors.into_iter().map(|error| error.to_string()).collect()
     }
 
+    fn send_item_pattern(guard: &str) -> String {
+        [
+            "p[$Wrapper: adt, $Parameter: type, $MappedType: type] = {",
+            "    struct $Wrapper<..> { .. }",
+            "    $marker: unsafe impl<..> core::marker::Send for $Wrapper<..> where .. {}",
+            "} where {",
+            guard,
+            "}",
+        ]
+        .join("\n")
+    }
+
     #[test]
     fn lowers_item_pattern_syntax_flags() {
         let arena = &*Box::leak(Box::new(Arena::default()));
@@ -570,7 +582,11 @@ send_variance[
     where ..
     {}
 } where {
-    true()
+    has_type_parameters($Wrapper)
+    && type_parameter_of($Parameter, $Wrapper)
+    && type_parameter_maps_to($Parameter, $MappedType, $send_impl)
+    && owns_type($Wrapper, $Parameter)
+    && !is_send_in($MappedType, $send_impl)
 }
 "#,
         );
@@ -807,7 +823,7 @@ p[$Wrapper: adt] = {
     }
 
     #[test]
-    fn rejects_predicates_other_than_true_and_false_in_item_guards() {
+    fn rejects_function_predicates_in_item_guards() {
         let arena = &*Box::leak(Box::new(Arena::default()));
         let mctx = &*Box::leak(Box::new(MetaContext::new(arena)));
         let source = arena.alloc_str(
@@ -870,6 +886,56 @@ p[$Wrapper: adt] = {
                 .to_string()
                 .contains("Attributes are not supported in an item guard")),
             "expected unsupported-item-attribute error, got: {errors:#?}"
+        );
+    }
+
+    #[test]
+    fn validates_item_predicate_modes_and_sorts() {
+        let errors = item_meta_errors(&send_item_pattern("has_type_parameters()"), &[]);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("expects 1 arguments, but received 0")),
+            "expected arity error, got: {errors:#?}"
+        );
+
+        let errors = item_meta_errors(&send_item_pattern("owns_type($Parameter, $Parameter)"), &[]);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("Argument `$Parameter`") && error.contains("must be a adt")),
+            "expected argument-sort error, got: {errors:#?}"
+        );
+
+        let errors = item_meta_errors(
+            &send_item_pattern(
+                "type_parameter_maps_to($Parameter, $MappedType, $marker)\n\
+                 && type_parameter_of($Parameter, $Wrapper)",
+            ),
+            &[],
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| { error.contains("Input `$Parameter`") && error.contains("is not bound") }),
+            "expected binding-order error, got: {errors:#?}"
+        );
+
+        let errors = item_meta_errors(&send_item_pattern("!type_parameter_of($Parameter, $Wrapper)"), &[]);
+        assert!(
+            errors.iter().any(|error| error.contains("cannot be negated")),
+            "expected closed-negation error, got: {errors:#?}"
+        );
+
+        let errors = item_meta_errors(
+            &send_item_pattern("(type_parameter_of($Parameter, $Wrapper) || true())"),
+            &[],
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("not supported inside a disjunction")),
+            "expected relational-disjunction error, got: {errors:#?}"
         );
     }
 }

--- a/crates/rpl_context/src/pat/non_local_meta_vars.rs
+++ b/crates/rpl_context/src/pat/non_local_meta_vars.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use rpl_constraints::predicates::PredicateConjunction;
 use rpl_meta::collect_elems_separated_by_comma;
 use rpl_meta::symbol_table::{GetType, WithPath};
-use rpl_parser::generics::Choice4;
+use rpl_parser::generics::Choice5;
 use rpl_parser::pairs;
 use rustc_index::IndexVec;
 use rustc_span::Symbol;
@@ -95,6 +95,12 @@ pub struct LocalVar<'pcx> {
     pub ty: Ty<'pcx>,
 }
 
+#[derive(Clone, Debug)]
+pub struct AccessVar {
+    pub name: Symbol,
+    pub pred: PredicateConjunction,
+}
+
 impl<'pcx> LocalVar<'pcx> {
     pub fn new(idx: Local, name: Symbol, ty: Ty<'pcx>) -> Self {
         Self { idx, name, ty }
@@ -109,6 +115,7 @@ pub struct NonLocalMetaVars<'pcx> {
     pub local_names: IndexVec<Local, Symbol>,
     pub ty_vars: IndexVec<TyVarIdx, TyVar>,
     pub adt_vars: IndexVec<AdtVarIdx, AdtVar>,
+    pub access_vars: Vec<AccessVar>,
     pub const_vars: IndexVec<ConstVarIdx, ConstVar<'pcx>>,
     pub place_vars: IndexVec<PlaceVarIdx, PlaceVar<'pcx>>,
     pub locals: IndexVec<Local, LocalVar<'pcx>>,
@@ -125,6 +132,12 @@ impl<'pcx> NonLocalMetaVars<'pcx> {
         let idx = self.adt_vars.next_index();
         let pred = preds.unwrap_or_default();
         self.adt_vars.push(AdtVar { idx, name, pred });
+    }
+    pub fn add_access_var(&mut self, name: Symbol, preds: Option<PredicateConjunction>) {
+        self.access_vars.push(AccessVar {
+            name,
+            pred: preds.unwrap_or_default(),
+        });
     }
     pub fn add_const_var(&mut self, name: Symbol, ty: Ty<'pcx>) {
         let idx = self.const_vars.next_index();
@@ -151,6 +164,7 @@ impl<'pcx> NonLocalMetaVars<'pcx> {
             // handle the type meta variable first
             let mut type_vars = Vec::new();
             let mut adt_vars = Vec::new();
+            let mut access_vars = Vec::new();
             let mut konst_vars = Vec::new();
             let mut place_vars = Vec::new();
             for decl in decls {
@@ -163,10 +177,11 @@ impl<'pcx> NonLocalMetaVars<'pcx> {
                     .transpose()
                     .expect("invalid predicates in meta variable decls");
                 match ty.deref() {
-                    Choice4::_0(_ty) => type_vars.push((ident, preds)),
-                    Choice4::_1(_adt) => adt_vars.push((ident, preds)),
-                    Choice4::_2(konst) => konst_vars.push((ident, konst)),
-                    Choice4::_3(place) => place_vars.push((ident, place)),
+                    Choice5::_0(_ty) => type_vars.push((ident, preds)),
+                    Choice5::_1(_adt) => adt_vars.push((ident, preds)),
+                    Choice5::_2(_access) => access_vars.push((ident, preds)),
+                    Choice5::_3(konst) => konst_vars.push((ident, konst)),
+                    Choice5::_4(place) => place_vars.push((ident, place)),
                 }
             }
             for (ident, pred_opt) in type_vars {
@@ -174,6 +189,9 @@ impl<'pcx> NonLocalMetaVars<'pcx> {
             }
             for (ident, pred_opt) in adt_vars {
                 meta.add_adt_var(ident, pred_opt);
+            }
+            for (ident, pred_opt) in access_vars {
+                meta.add_access_var(ident, pred_opt);
             }
             for (ident, konst) in konst_vars {
                 let ty = Ty::from(with_path(p, konst.get_matched().2), pcx, fn_sym_tab);

--- a/crates/rpl_context/src/pat/non_local_meta_vars.rs
+++ b/crates/rpl_context/src/pat/non_local_meta_vars.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use rpl_constraints::predicates::PredicateConjunction;
 use rpl_meta::collect_elems_separated_by_comma;
 use rpl_meta::symbol_table::{GetType, WithPath};
-use rpl_parser::generics::Choice3;
+use rpl_parser::generics::Choice4;
 use rpl_parser::pairs;
 use rustc_index::IndexVec;
 use rustc_span::Symbol;
@@ -24,6 +24,12 @@ rustc_index::newtype_index! {
 }
 
 rustc_index::newtype_index! {
+    #[debug_format = "?A{}"]
+    #[orderable]
+    pub struct AdtVarIdx {}
+}
+
+rustc_index::newtype_index! {
     #[debug_format = "?P{}"]
     #[orderable]
     pub struct PlaceVarIdx {}
@@ -32,6 +38,13 @@ rustc_index::newtype_index! {
 #[derive(Clone)]
 pub struct TyVar {
     pub idx: TyVarIdx,
+    pub name: Symbol,
+    pub pred: PredicateConjunction,
+}
+
+#[derive(Clone, Debug)]
+pub struct AdtVar {
+    pub idx: AdtVarIdx,
     pub name: Symbol,
     pub pred: PredicateConjunction,
 }
@@ -95,6 +108,7 @@ pub struct NonLocalMetaVars<'pcx> {
     pub place_var_names: IndexVec<PlaceVarIdx, Symbol>,
     pub local_names: IndexVec<Local, Symbol>,
     pub ty_vars: IndexVec<TyVarIdx, TyVar>,
+    pub adt_vars: IndexVec<AdtVarIdx, AdtVar>,
     pub const_vars: IndexVec<ConstVarIdx, ConstVar<'pcx>>,
     pub place_vars: IndexVec<PlaceVarIdx, PlaceVar<'pcx>>,
     pub locals: IndexVec<Local, LocalVar<'pcx>>,
@@ -106,6 +120,11 @@ impl<'pcx> NonLocalMetaVars<'pcx> {
         let pred = preds.unwrap_or_default();
         let ty_var = TyVar { idx, name, pred };
         self.ty_vars.push(ty_var);
+    }
+    pub fn add_adt_var(&mut self, name: Symbol, preds: Option<PredicateConjunction>) {
+        let idx = self.adt_vars.next_index();
+        let pred = preds.unwrap_or_default();
+        self.adt_vars.push(AdtVar { idx, name, pred });
     }
     pub fn add_const_var(&mut self, name: Symbol, ty: Ty<'pcx>) {
         let idx = self.const_vars.next_index();
@@ -131,6 +150,7 @@ impl<'pcx> NonLocalMetaVars<'pcx> {
             let decls = collect_elems_separated_by_comma!(decls).collect::<Vec<_>>();
             // handle the type meta variable first
             let mut type_vars = Vec::new();
+            let mut adt_vars = Vec::new();
             let mut konst_vars = Vec::new();
             let mut place_vars = Vec::new();
             for decl in decls {
@@ -143,13 +163,17 @@ impl<'pcx> NonLocalMetaVars<'pcx> {
                     .transpose()
                     .expect("invalid predicates in meta variable decls");
                 match ty.deref() {
-                    Choice3::_0(_ty) => type_vars.push((ident, preds)),
-                    Choice3::_1(konst) => konst_vars.push((ident, konst)),
-                    Choice3::_2(place) => place_vars.push((ident, place)),
+                    Choice4::_0(_ty) => type_vars.push((ident, preds)),
+                    Choice4::_1(_adt) => adt_vars.push((ident, preds)),
+                    Choice4::_2(konst) => konst_vars.push((ident, konst)),
+                    Choice4::_3(place) => place_vars.push((ident, place)),
                 }
             }
             for (ident, pred_opt) in type_vars {
                 meta.add_ty_var(ident, pred_opt);
+            }
+            for (ident, pred_opt) in adt_vars {
+                meta.add_adt_var(ident, pred_opt);
             }
             for (ident, konst) in konst_vars {
                 let ty = Ty::from(with_path(p, konst.get_matched().2), pcx, fn_sym_tab);

--- a/crates/rpl_context/src/pat/ty.rs
+++ b/crates/rpl_context/src/pat/ty.rs
@@ -146,7 +146,7 @@ impl<'pcx> Ty<'pcx> {
                     };
                     pcx.mk_var_ty(ty_meta_var)
                 },
-                MetaVariable::Const(..) | MetaVariable::Place(..) => {
+                MetaVariable::Const(..) | MetaVariable::Place(..) | MetaVariable::Access(..) => {
                     panic!("A non-type meta variable used as a type variable")
                 },
                 MetaVariable::AdtPat(_, name) => pcx.mk_adt_pat_ty(Symbol::intern(name)),

--- a/crates/rpl_context/src/pat/ty.rs
+++ b/crates/rpl_context/src/pat/ty.rs
@@ -17,6 +17,24 @@ use crate::PatCtxt;
 use crate::cvt_prim_ty::CvtPrimTy;
 use crate::pat::non_local_meta_vars::{ConstVar, TyVar};
 
+fn expand_imported_path<'mcx>(
+    path: WithPath<'mcx, &'mcx pairs::Path<'mcx>>,
+    symbol_table: &impl GetType<'mcx>,
+) -> utils::Path<'mcx> {
+    let source_path = path.path;
+    let mut path = utils::Path::from(path.inner);
+    let mut used = FxHashSet::default();
+    while let Some(ident) = path.leading_ident()
+        && let Ok(TypeOrPath::Path(mapped)) = symbol_table.get_type_or_path(&WithPath::new(source_path, ident))
+    {
+        if !used.insert(mapped) {
+            break;
+        }
+        path = path.replace_leading_ident(utils::Path::from(mapped));
+    }
+    path
+}
+
 // FIXME: Use interning for the types
 #[derive(Clone, Copy)]
 #[rustc_pass_by_value]
@@ -381,6 +399,14 @@ impl<'pcx> Path<'pcx> {
         //FIXME: how about the path arguments?
         items.extend(path.segments.iter().map(|seg| Symbol::intern(seg.0.span.as_str())));
         ItemPath(pcx.mk_slice(&items)).into()
+    }
+
+    pub(crate) fn from_imported_pairs<'mcx>(
+        path: WithPath<'mcx, &'mcx pairs::Path<'mcx>>,
+        pcx: PatCtxt<'pcx>,
+        symbol_table: &impl GetType<'mcx>,
+    ) -> Self {
+        Self::from(expand_imported_path(path, symbol_table), pcx)
     }
 }
 

--- a/crates/rpl_doc/src/extract.rs
+++ b/crates/rpl_doc/src/extract.rs
@@ -189,8 +189,14 @@ fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>, source: &'i str) -> DocI
         .MetaVariableDeclList()
         .map(|m| collapse_whitespace(m.span.as_str()));
 
-    let (signature, body_raw) = split_signature_and_body(item.RustItemsOrPatternOperation());
+    let node = item.RustItemsOrPatternOperation();
+    let (signature, body_raw) = split_signature_and_body(node);
     let body_source = dedent(&body_raw);
+    let where_source = node
+        .RustItemsWithConstraint()
+        .and_then(|items| items.WhereBlock())
+        .or_else(|| node.RustItemWithConstraint().and_then(|item| item.WhereBlock()))
+        .map(|where_block| where_block.span.as_str().trim().to_string());
 
     DocItem {
         name,
@@ -199,6 +205,7 @@ fn build_doc_item<'i>(item: &pairs::RPLPatternItem<'i>, source: &'i str) -> DocI
         diag_attr,
         signature,
         body_source,
+        where_source,
     }
 }
 
@@ -285,9 +292,9 @@ fn extract_diag_attr_value(attr: &pairs::Attr<'_>) -> Option<String> {
 /// Layout per variant:
 /// - `PatternOperation`: pure expression (e.g. `divergent[$T = $T]`). The entire text is the
 ///   signature; there is no body.
-/// - `RustItemsWithConstraint` (`{ item+ }`): a wrapping brace block whose contents are several
-///   items. The signature is empty; the body is the text strictly between the outer `LeftBrace` and
-///   `RightBrace`.
+/// - `RustItemsWithConstraint` (`{ item+ } where { ... }?`): a wrapping brace block whose contents
+///   are several items. The signature is empty; the body is the text strictly between the outer
+///   `LeftBrace` and `RightBrace`. The optional bundle constraint is extracted separately.
 /// - `RustItemWithConstraint` (`Attr* ~ RustItem ~ WhereBlock?`): unwraps to one `RustItem`
 ///   (`Fn`/`Struct`/`Enum`/`Impl`). The signature runs from the start of the node up to the item's
 ///   opening brace, and the body is the text between that brace and its matching closer:
@@ -308,7 +315,8 @@ fn split_signature_and_body(node: &pairs::RustItemsOrPatternOperation<'_>) -> (S
     }
 
     // `RustItemsWithConstraint` is `LeftBrace ~ RustItemWithConstraint+ ~
-    // RightBrace`. There is no signature; the body is the inside-of-braces.
+    // RightBrace ~ WhereBlock?`. There is no signature; the body is the
+    // inside-of-braces.
     if let Some(items) = node.RustItemsWithConstraint() {
         let lb = items.LeftBrace().span;
         let rb = items.RightBrace().span;
@@ -611,6 +619,26 @@ patt {
         assert!(!mv.contains('\n'));
         assert!(mv.contains("$T: type"));
         assert!(mv.contains("$U: type"));
+    }
+
+    #[test]
+    fn bundle_where_block_is_preserved() {
+        let src = r#"
+pattern Foo
+patt {
+    p_foo[$Wrapper: adt] = {
+        struct $Wrapper<..> { .. }
+    } where {
+        true()
+    }
+}
+"#;
+        let main = parse(src);
+        let doc = build_doc_file(Path::new("/x/Foo.rpl"), src, &main);
+        assert_eq!(
+            doc.patterns[0].where_source.as_deref(),
+            Some("where {\n        true()\n    }")
+        );
     }
 
     #[test]

--- a/crates/rpl_doc/src/model.rs
+++ b/crates/rpl_doc/src/model.rs
@@ -44,6 +44,8 @@ pub struct DocItem {
     pub signature: String,
     /// Body text between matching `{` and `}`, uniformly dedented.
     pub body_source: String,
+    /// Trailing `where { ... }` block attached to the item or item bundle.
+    pub where_source: Option<String>,
 }
 
 /// A diagnostic group: `[/// docs]* name = { fields... }`.

--- a/crates/rpl_doc/src/render.rs
+++ b/crates/rpl_doc/src/render.rs
@@ -130,6 +130,11 @@ fn render_item(out: &mut String, item: &DocItem) {
         out.push_str(&format!("**Diagnostic:** [`{diag}`](#diagnostic-{diag})\n\n",));
     }
     out.push_str(&format!("**Signature:** {}\n\n", inline_code(&item.signature)));
+    if let Some(where_source) = &item.where_source {
+        out.push_str("**Constraints:**\n\n");
+        write_fence(out, "rpl", where_source);
+        out.push('\n');
+    }
     out.push_str("<details><summary>Pattern body</summary>\n\n");
     write_fence(out, "rpl", &item.body_source);
     out.push_str("</details>\n\n");
@@ -263,6 +268,7 @@ mod render_doc_file_tests {
             diag_attr: Some("p_diag".into()),
             signature: "fn _ (..) -> _".into(),
             body_source: "let x = 1;".into(),
+            where_source: Some("where {\n    true()\n}".into()),
         });
         let out = render(&doc);
         assert!(out.contains("## Patterns"));
@@ -270,6 +276,8 @@ mod render_doc_file_tests {
         assert!(out.contains("docs"));
         assert!(out.contains("[`p_diag`](#diagnostic-p_diag)"));
         assert!(out.contains("**Signature:** `fn _ (..) -> _`"));
+        assert!(out.contains("**Constraints:**"));
+        assert!(out.contains("```rpl\nwhere {\n    true()\n}\n```"));
         assert!(out.contains("```rpl\nlet x = 1;\n```"));
     }
 
@@ -321,6 +329,7 @@ mod render_doc_file_tests {
             diag_attr: None,
             signature: "fn _ (..) -> _".into(),
             body_source: "let x = 1;".into(),
+            where_source: None,
         });
         let out = render(&doc);
         assert!(out.contains("### `p_foo[$T: type]`"));

--- a/crates/rpl_driver/src/lib.rs
+++ b/crates/rpl_driver/src/lib.rs
@@ -20,6 +20,7 @@ use std::cell::RefCell;
 use std::convert::identity;
 
 use rpl_constraints::predicates::BodyInfoCache;
+use rpl_constraints::tribool::TriBool;
 use rpl_context::PatCtxt;
 use rpl_context::pat::{DynamicError, PatternItem};
 use rpl_match::item::{ItemPredicateEvaluator, MatchItemCtxt};
@@ -316,8 +317,8 @@ impl<'tcx> CheckFnCtxt<'_, 'tcx> {
                 let Some(matched) = MatchItemCtxt::new(self.tcx, rust_items).match_impl(impl_def_id, impl_) else {
                     continue;
                 };
-                match ItemPredicateEvaluator::new(&matched).evaluate(rust_items.item_constraints.as_ref()) {
-                    Ok(true) => {
+                match ItemPredicateEvaluator::new(self.tcx, &matched).evaluate(rust_items.item_constraints.as_ref()) {
+                    Ok(TriBool::True) => {
                         let error = Box::new(DynamicError::default_diagnostic(name, span));
                         self.tcx.emit_node_span_lint(
                             error.lint(),
@@ -326,7 +327,10 @@ impl<'tcx> CheckFnCtxt<'_, 'tcx> {
                             error,
                         );
                     },
-                    Ok(false) => {},
+                    Ok(TriBool::False) => {},
+                    Ok(TriBool::Unknown) => {
+                        debug!(?name, "item pattern evaluation was incomplete");
+                    },
                     Err(error) => {
                         debug!(
                             ?error,

--- a/crates/rpl_driver/src/lib.rs
+++ b/crates/rpl_driver/src/lib.rs
@@ -21,7 +21,8 @@ use std::convert::identity;
 
 use rpl_constraints::predicates::BodyInfoCache;
 use rpl_context::PatCtxt;
-use rpl_context::pat::DynamicError;
+use rpl_context::pat::{DynamicError, PatternItem};
+use rpl_match::item::{ItemPredicateEvaluator, MatchItemCtxt};
 use rpl_match::matches::artifact::{NormalizedMatched, NormalizedSpanned};
 use rpl_match::session::{MatchCollectCtxt, MatchSession, SessionConfig};
 use rpl_match::{CrateItemIndex, MatchSlot, MultiMatched, OwnedLintMatch};
@@ -38,6 +39,7 @@ use rustc_middle::util::Providers;
 use rustc_session::declare_tool_lint;
 use rustc_span::symbol::Ident;
 use rustc_span::{Span, Symbol};
+use tracing::{debug, instrument};
 
 #[cfg(feature = "timing")]
 mod errors;
@@ -258,6 +260,7 @@ impl<'tcx> Visitor<'tcx> for CheckFnCtxt<'_, 'tcx> {
                 }
             },
             hir::ItemKind::Impl(impl_) => {
+                self.check_item_impl(item.owner_id.def_id, impl_);
                 for impl_item in impl_.items {
                     self.visit_impl_item_ref(impl_item);
                 }
@@ -300,5 +303,39 @@ impl<'tcx> CheckFnCtxt<'_, 'tcx> {
 
     fn visit_impl_item_ref(&mut self, impl_item: &'tcx hir::ImplItemRef) {
         let _ = impl_item;
+    }
+
+    #[instrument(level = "debug", skip(self, impl_))]
+    fn check_item_impl(&self, impl_def_id: LocalDefId, impl_: &hir::Impl<'tcx>) {
+        let span = self.tcx.def_span(impl_def_id);
+        self.pcx.for_each_rpl_pattern(|_id, pattern| {
+            for (&name, pat_item) in &pattern.patt_block {
+                let PatternItem::RustItems(rust_items) = pat_item else {
+                    continue;
+                };
+                let Some(matched) = MatchItemCtxt::new(self.tcx, rust_items).match_impl(impl_def_id, impl_) else {
+                    continue;
+                };
+                match ItemPredicateEvaluator::new(&matched).evaluate(rust_items.item_constraints.as_ref()) {
+                    Ok(true) => {
+                        let error = Box::new(DynamicError::default_diagnostic(name, span));
+                        self.tcx.emit_node_span_lint(
+                            error.lint(),
+                            self.tcx.local_def_id_to_hir_id(impl_def_id),
+                            error.primary_span().clone(),
+                            error,
+                        );
+                    },
+                    Ok(false) => {},
+                    Err(error) => {
+                        debug!(
+                            ?error,
+                            ?name,
+                            "item pattern uses a predicate unsupported by the item matcher"
+                        );
+                    },
+                }
+            }
+        });
     }
 }

--- a/crates/rpl_match/src/item.rs
+++ b/crates/rpl_match/src/item.rs
@@ -1,0 +1,224 @@
+use rpl_constraints::Constraints;
+use rpl_constraints::predicates::PredicateKind;
+use rpl_context::pat;
+use rpl_resolve::{PatItemKind, def_path_res};
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir as hir;
+use rustc_hir::def::Res;
+use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::Symbol;
+
+#[derive(Debug)]
+pub struct ItemMatched<'tcx> {
+    pub root_impl: LocalDefId,
+    pub self_ty: Ty<'tcx>,
+    pub self_args: ty::GenericArgsRef<'tcx>,
+    pub adts: FxHashMap<Symbol, DefId>,
+    pub impls: FxHashMap<Symbol, LocalDefId>,
+}
+
+pub struct MatchItemCtxt<'pat, 'pcx, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pat: &'pat pat::RustItems<'pcx>,
+}
+
+impl<'pat, 'pcx, 'tcx> MatchItemCtxt<'pat, 'pcx, 'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, pat: &'pat pat::RustItems<'pcx>) -> Self {
+        Self { tcx, pat }
+    }
+
+    #[instrument(level = "debug", skip(self, impl_), ret)]
+    pub fn match_impl(&self, impl_def_id: LocalDefId, impl_: &hir::Impl<'tcx>) -> Option<ItemMatched<'tcx>> {
+        if !matches!(impl_.safety, hir::Safety::Unsafe) || !matches!(impl_.polarity, hir::ImplPolarity::Positive) {
+            return None;
+        }
+
+        let impl_pat = self.supported_impl_pattern()?;
+        let trait_ref = self.tcx.impl_trait_ref(impl_def_id.to_def_id())?.instantiate_identity();
+        if !trait_path_matches(self.tcx, impl_pat.trait_path?, trait_ref.def_id) {
+            return None;
+        }
+
+        let self_ty = trait_ref.self_ty();
+        let ty::Adt(adt, self_args) = *self_ty.kind() else {
+            return None;
+        };
+        if !adt.is_struct() || !adt.did().is_local() {
+            return None;
+        }
+
+        let pat::TyKind::AdtPat(wrapper) = impl_pat.self_ty.ty.kind() else {
+            return None;
+        };
+        let adt_pat = self.pat.get_adt(*wrapper)?;
+        if !supported_struct_pattern(adt_pat) {
+            return None;
+        }
+
+        let marker = impl_pat.binding?;
+        let mut adts = FxHashMap::default();
+        adts.insert(*wrapper, adt.did());
+        let mut impls = FxHashMap::default();
+        impls.insert(marker, impl_def_id);
+
+        Some(ItemMatched {
+            root_impl: impl_def_id,
+            self_ty,
+            self_args,
+            adts,
+            impls,
+        })
+    }
+
+    fn supported_impl_pattern(&self) -> Option<&pat::Impl<'pcx>> {
+        if self.pat.adts.len() != 1
+            || self.pat.impls.len() != 1
+            || self.pat.fns.iter().next().is_some()
+            || self.pat.meta.adt_vars.len() != 1
+            || self
+                .pat
+                .meta
+                .adt_vars
+                .iter()
+                .any(|adt_var| !adt_var.pred.clauses.is_empty())
+            || !self.pat.meta.ty_vars.is_empty()
+            || !self.pat.meta.const_vars.is_empty()
+            || !self.pat.meta.place_vars.is_empty()
+        {
+            return None;
+        }
+
+        let impl_pat = self.pat.impls.first()?;
+        (impl_pat.binding.is_some()
+            && impl_pat.safety == pat::SafetyPat::Unsafe
+            && impl_pat.polarity == pat::ImplPolarityPat::Positive
+            && impl_pat.generics.rest == pat::RestPat::Rest
+            && impl_pat.self_ty.generic_args == pat::RestPat::Rest
+            && impl_pat.where_clause == pat::RestPat::Rest
+            && impl_pat.fns.is_empty()
+            && impl_pat.constraints.preds.is_empty()
+            && !impl_pat.constraints.has_attributes)
+            .then_some(impl_pat)
+    }
+}
+
+fn supported_struct_pattern(adt_pat: &pat::Adt<'_>) -> bool {
+    let pat::AdtKind::Struct(variant) = &adt_pat.kind else {
+        return false;
+    };
+    adt_pat.generics.rest == pat::RestPat::Rest
+        && variant.rest == pat::RestPat::Rest
+        && variant.fields.is_empty()
+        && adt_pat.constraints.preds.is_empty()
+        && !adt_pat.constraints.has_attributes
+}
+
+fn trait_path_matches(tcx: TyCtxt<'_>, path: pat::Path<'_>, actual: DefId) -> bool {
+    let pat::Path::Item(path) = path else {
+        return false;
+    };
+    let mut resolved = def_path_res(tcx, path.0, PatItemKind::Trait)
+        .into_iter()
+        .filter_map(|res| match res {
+            Res::Def(_, def_id) => Some(def_id),
+            _ => None,
+        });
+    let Some(expected) = resolved.next() else {
+        return false;
+    };
+    expected == actual && resolved.all(|def_id| def_id == expected)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsupportedItemPredicate {
+    pub name: String,
+}
+
+pub struct ItemPredicateEvaluator<'matched, 'tcx> {
+    matched: &'matched ItemMatched<'tcx>,
+}
+
+impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
+    pub fn new(matched: &'matched ItemMatched<'tcx>) -> Self {
+        Self { matched }
+    }
+
+    #[instrument(level = "debug", skip(self, constraints), fields(root_impl = ?self.matched.root_impl), ret)]
+    pub fn evaluate(&self, constraints: Option<&Constraints>) -> Result<bool, UnsupportedItemPredicate> {
+        evaluate_item_constraints(constraints)
+    }
+}
+
+fn evaluate_item_constraints(constraints: Option<&Constraints>) -> Result<bool, UnsupportedItemPredicate> {
+    let Some(constraints) = constraints else {
+        return Ok(true);
+    };
+    if constraints.has_attributes {
+        return Err(UnsupportedItemPredicate {
+            name: "<attribute>".to_string(),
+        });
+    }
+
+    let mut result = true;
+    for conjunction in &constraints.preds {
+        let mut conjunction_result = true;
+        for clause in &conjunction.clauses {
+            let mut clause_result = false;
+            for term in &clause.terms {
+                let term_result = match term.kind {
+                    PredicateKind::Trivial(predicate)
+                        if matches!(term.name.as_str(), "true" | "false") && term.args.is_empty() =>
+                    {
+                        predicate()
+                    },
+                    _ => {
+                        return Err(UnsupportedItemPredicate {
+                            name: term.name.clone(),
+                        });
+                    },
+                };
+                clause_result |= if term.is_neg { !term_result } else { term_result };
+            }
+            conjunction_result &= clause_result;
+        }
+        result &= conjunction_result;
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use rpl_constraints::Constraints;
+    use rpl_constraints::predicates::{
+        PredicateClause, PredicateConjunction, PredicateKind, PredicateTerm, TrivialPredsFnPtr,
+    };
+
+    use super::evaluate_item_constraints;
+
+    fn guard(name: &str, predicate: TrivialPredsFnPtr) -> Constraints {
+        Constraints {
+            preds: vec![PredicateConjunction {
+                clauses: vec![PredicateClause {
+                    terms: vec![PredicateTerm {
+                        name: name.to_string(),
+                        kind: PredicateKind::Trivial(predicate),
+                        args: Vec::new(),
+                        is_neg: false,
+                    }],
+                }],
+            }],
+            attrs: Default::default(),
+            has_attributes: false,
+        }
+    }
+
+    #[test]
+    fn evaluates_true_and_false_item_guards() {
+        let true_guard = guard("true", rpl_constraints::predicates::r#true);
+        let false_guard = guard("false", rpl_constraints::predicates::r#false);
+
+        assert_eq!(evaluate_item_constraints(Some(&true_guard)), Ok(true));
+        assert_eq!(evaluate_item_constraints(Some(&false_guard)), Ok(false));
+    }
+}

--- a/crates/rpl_match/src/item.rs
+++ b/crates/rpl_match/src/item.rs
@@ -1,5 +1,3 @@
-use rpl_constraints::Constraints;
-use rpl_constraints::predicates::PredicateKind;
 use rpl_context::pat;
 use rpl_resolve::{PatItemKind, def_path_res};
 use rustc_data_structures::fx::FxHashMap;
@@ -8,6 +6,10 @@ use rustc_hir::def::Res;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Symbol;
+
+mod predicate;
+
+pub use predicate::{ItemPredicateEvaluator, UnsupportedItemPredicate};
 
 #[derive(Debug)]
 pub struct ItemMatched<'tcx> {
@@ -82,7 +84,6 @@ impl<'pat, 'pcx, 'tcx> MatchItemCtxt<'pat, 'pcx, 'tcx> {
                 .adt_vars
                 .iter()
                 .any(|adt_var| !adt_var.pred.clauses.is_empty())
-            || !self.pat.meta.ty_vars.is_empty()
             || !self.pat.meta.const_vars.is_empty()
             || !self.pat.meta.place_vars.is_empty()
         {
@@ -128,97 +129,4 @@ fn trait_path_matches(tcx: TyCtxt<'_>, path: pat::Path<'_>, actual: DefId) -> bo
         return false;
     };
     expected == actual && resolved.all(|def_id| def_id == expected)
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UnsupportedItemPredicate {
-    pub name: String,
-}
-
-pub struct ItemPredicateEvaluator<'matched, 'tcx> {
-    matched: &'matched ItemMatched<'tcx>,
-}
-
-impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
-    pub fn new(matched: &'matched ItemMatched<'tcx>) -> Self {
-        Self { matched }
-    }
-
-    #[instrument(level = "debug", skip(self, constraints), fields(root_impl = ?self.matched.root_impl), ret)]
-    pub fn evaluate(&self, constraints: Option<&Constraints>) -> Result<bool, UnsupportedItemPredicate> {
-        evaluate_item_constraints(constraints)
-    }
-}
-
-fn evaluate_item_constraints(constraints: Option<&Constraints>) -> Result<bool, UnsupportedItemPredicate> {
-    let Some(constraints) = constraints else {
-        return Ok(true);
-    };
-    if constraints.has_attributes {
-        return Err(UnsupportedItemPredicate {
-            name: "<attribute>".to_string(),
-        });
-    }
-
-    let mut result = true;
-    for conjunction in &constraints.preds {
-        let mut conjunction_result = true;
-        for clause in &conjunction.clauses {
-            let mut clause_result = false;
-            for term in &clause.terms {
-                let term_result = match term.kind {
-                    PredicateKind::Trivial(predicate)
-                        if matches!(term.name.as_str(), "true" | "false") && term.args.is_empty() =>
-                    {
-                        predicate()
-                    },
-                    _ => {
-                        return Err(UnsupportedItemPredicate {
-                            name: term.name.clone(),
-                        });
-                    },
-                };
-                clause_result |= if term.is_neg { !term_result } else { term_result };
-            }
-            conjunction_result &= clause_result;
-        }
-        result &= conjunction_result;
-    }
-    Ok(result)
-}
-
-#[cfg(test)]
-mod tests {
-    use rpl_constraints::Constraints;
-    use rpl_constraints::predicates::{
-        PredicateClause, PredicateConjunction, PredicateKind, PredicateTerm, TrivialPredsFnPtr,
-    };
-
-    use super::evaluate_item_constraints;
-
-    fn guard(name: &str, predicate: TrivialPredsFnPtr) -> Constraints {
-        Constraints {
-            preds: vec![PredicateConjunction {
-                clauses: vec![PredicateClause {
-                    terms: vec![PredicateTerm {
-                        name: name.to_string(),
-                        kind: PredicateKind::Trivial(predicate),
-                        args: Vec::new(),
-                        is_neg: false,
-                    }],
-                }],
-            }],
-            attrs: Default::default(),
-            has_attributes: false,
-        }
-    }
-
-    #[test]
-    fn evaluates_true_and_false_item_guards() {
-        let true_guard = guard("true", rpl_constraints::predicates::r#true);
-        let false_guard = guard("false", rpl_constraints::predicates::r#false);
-
-        assert_eq!(evaluate_item_constraints(Some(&true_guard)), Ok(true));
-        assert_eq!(evaluate_item_constraints(Some(&false_guard)), Ok(false));
-    }
 }

--- a/crates/rpl_match/src/item/predicate.rs
+++ b/crates/rpl_match/src/item/predicate.rs
@@ -4,7 +4,9 @@ use rpl_constraints::predicates::{
 };
 use rpl_constraints::tribool::TriBool;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::{Mutability, Safety};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Symbol;
 
@@ -30,6 +32,12 @@ enum ItemValue<'tcx> {
     Impl(LocalDefId),
     TypeParameter(TypeParameter<'tcx>),
     Ty(Ty<'tcx>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SharedRefAccessKind {
+    Exclusive,
+    Concurrent,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -255,6 +263,12 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
             ItemPredicate::OwnsType => self.owns_type(row, term),
             ItemPredicate::IsSendIn => self.is_send_in(row, term),
             ItemPredicate::IsSyncIn => self.is_sync_in(row, term),
+            ItemPredicate::ResourceExclusivelyAccessibleFromSharedRefIn => {
+                self.resource_accessible_from_shared_ref_in(row, term, SharedRefAccessKind::Exclusive)
+            },
+            ItemPredicate::ResourceConcurrentlyAccessibleFromSharedRefIn => {
+                self.resource_accessible_from_shared_ref_in(row, term, SharedRefAccessKind::Concurrent)
+            },
         }
     }
 
@@ -418,6 +432,251 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
         // decision later without changing the predicate contract.
         let result = rpl_constraints::predicates::is_sync(self.tcx, typing_env, ty);
         Ok(EvalRows::decision(row, result.into()))
+    }
+
+    fn resource_accessible_from_shared_ref_in(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        kind: SharedRefAccessKind,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let output = self.meta_arg(term, 0)?;
+        let wrapper = self.adt_arg(&row, term, 1)?;
+        let parameter = self.type_parameter_arg(&row, term, 2)?;
+        let mapped = self.ty_arg(&row, term, 3)?;
+        let marker = self.impl_arg(&row, term, 4)?;
+
+        if parameter.owner != wrapper || !self.marker_maps_parameter_to(marker, parameter, mapped) {
+            return Ok(EvalRows::empty());
+        }
+
+        // Phase one recognizes direct safe `&self` signatures and uses the matched type
+        // argument as the resource. The public relation is intentionally broader: a future
+        // implementation may emit projected or carrier types after analyzing method bodies,
+        // guards, trait APIs, and specialized substitutions.
+        match self.shared_ref_access_kind(wrapper, parameter, kind) {
+            TriBool::True => Ok(row
+                .bind(output, ItemValue::Ty(mapped))
+                .map_or_else(EvalRows::empty, EvalRows::one)),
+            TriBool::False => Ok(EvalRows::empty()),
+            TriBool::Unknown => Ok(EvalRows::unknown()),
+        }
+    }
+
+    fn marker_maps_parameter_to(&self, marker: LocalDefId, parameter: TypeParameter<'tcx>, mapped: Ty<'tcx>) -> bool {
+        let Some(trait_ref) = self.tcx.impl_trait_ref(marker.to_def_id()) else {
+            return false;
+        };
+        let trait_ref = trait_ref.instantiate_identity();
+        let ty::Adt(adt, args) = *trait_ref.self_ty().kind() else {
+            return false;
+        };
+        adt.did() == parameter.owner
+            && args
+                .get(parameter.index as usize)
+                .and_then(|arg| arg.as_type())
+                .is_some_and(|ty| ty == mapped)
+    }
+
+    fn shared_ref_access_kind(
+        &self,
+        wrapper: DefId,
+        parameter: TypeParameter<'tcx>,
+        kind: SharedRefAccessKind,
+    ) -> TriBool {
+        let mut result = TriBool::False;
+        for &impl_def_id in self.tcx.inherent_impls(wrapper).iter() {
+            let impl_self_ty = self.tcx.type_of(impl_def_id).instantiate_identity();
+            let ty::Adt(adt, args) = *impl_self_ty.kind() else {
+                continue;
+            };
+            if adt.did() != wrapper {
+                continue;
+            }
+            let Some(impl_parameter) = args.get(parameter.index as usize).and_then(|arg| arg.as_type()) else {
+                result = result | TriBool::Unknown;
+                continue;
+            };
+            if !matches!(impl_parameter.kind(), ty::Param(_)) {
+                // Specialized inherent impls need unification with the matched marker impl. Keep
+                // this incomplete rather than joining evidence from incompatible substitutions.
+                result = result | TriBool::Unknown;
+                continue;
+            }
+
+            for &method in self.tcx.associated_item_def_ids(impl_def_id) {
+                if self.tcx.def_kind(method) != DefKind::AssocFn {
+                    continue;
+                }
+                let signature = self.tcx.fn_sig(method).instantiate_identity().skip_binder();
+                if signature.safety != Safety::Safe {
+                    continue;
+                }
+                let inputs = signature.inputs();
+                let Some((&receiver, arguments)) = inputs.split_first() else {
+                    continue;
+                };
+                if !self.is_direct_shared_receiver(receiver, wrapper) {
+                    continue;
+                }
+
+                let method_result = match kind {
+                    SharedRefAccessKind::Exclusive => {
+                        arguments.iter().copied().fold(TriBool::False, |found, ty| {
+                            found | self.contains_owned_parameter(ty, impl_parameter, &mut FxHashSet::default())
+                        }) | self.contains_exclusive_output_parameter(
+                            signature.output(),
+                            impl_parameter,
+                            &mut FxHashSet::default(),
+                        )
+                    },
+                    SharedRefAccessKind::Concurrent => self.contains_shared_output_parameter(
+                        signature.output(),
+                        impl_parameter,
+                        &mut FxHashSet::default(),
+                    ),
+                };
+                result = result | method_result;
+                if result == TriBool::True {
+                    return result;
+                }
+            }
+        }
+        result
+    }
+
+    fn is_direct_shared_receiver(&self, receiver: Ty<'tcx>, wrapper: DefId) -> bool {
+        let ty::Ref(_, self_ty, Mutability::Not) = *receiver.kind() else {
+            return false;
+        };
+        matches!(self_ty.kind(), ty::Adt(adt, _) if adt.did() == wrapper)
+    }
+
+    fn contains_owned_parameter(
+        &self,
+        ty: Ty<'tcx>,
+        parameter: Ty<'tcx>,
+        visited: &mut FxHashSet<Ty<'tcx>>,
+    ) -> TriBool {
+        if ty == parameter {
+            return TriBool::True;
+        }
+        if !visited.insert(ty) {
+            return TriBool::False;
+        }
+        match ty.kind() {
+            ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
+                found | self.contains_owned_parameter(ty, parameter, visited)
+            }),
+            ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) => {
+                self.contains_owned_parameter(*element, parameter, visited)
+            },
+            ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
+            ty::Adt(_, args) => args
+                .iter()
+                .filter_map(|arg| arg.as_type())
+                .fold(TriBool::False, |found, ty| {
+                    found | self.contains_owned_parameter(ty, parameter, visited)
+                }),
+            ty::Alias(..) => TriBool::Unknown,
+            ty::Ref(..) | ty::RawPtr(..) | ty::FnDef(..) | ty::FnPtr(..) => TriBool::False,
+            _ => TriBool::False,
+        }
+    }
+
+    fn contains_exclusive_output_parameter(
+        &self,
+        ty: Ty<'tcx>,
+        parameter: Ty<'tcx>,
+        visited: &mut FxHashSet<Ty<'tcx>>,
+    ) -> TriBool {
+        if ty == parameter {
+            return TriBool::True;
+        }
+        if !visited.insert(ty) {
+            return TriBool::False;
+        }
+        match ty.kind() {
+            ty::Ref(_, referent, Mutability::Mut) => self.contains_parameter_dependency(*referent, parameter, visited),
+            ty::Ref(_, _, Mutability::Not) | ty::RawPtr(..) => TriBool::False,
+            ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
+                found | self.contains_exclusive_output_parameter(ty, parameter, visited)
+            }),
+            ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) => {
+                self.contains_exclusive_output_parameter(*element, parameter, visited)
+            },
+            ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
+            ty::Adt(_, args) => args
+                .iter()
+                .filter_map(|arg| arg.as_type())
+                .fold(TriBool::False, |found, ty| {
+                    self.contains_exclusive_output_parameter(ty, parameter, visited) | found
+                }),
+            ty::Alias(..) => TriBool::Unknown,
+            ty::FnDef(..) | ty::FnPtr(..) => TriBool::False,
+            _ => TriBool::False,
+        }
+    }
+
+    fn contains_shared_output_parameter(
+        &self,
+        ty: Ty<'tcx>,
+        parameter: Ty<'tcx>,
+        visited: &mut FxHashSet<Ty<'tcx>>,
+    ) -> TriBool {
+        if !visited.insert(ty) {
+            return TriBool::False;
+        }
+        match ty.kind() {
+            ty::Ref(_, referent, Mutability::Not) => self.contains_parameter_dependency(*referent, parameter, visited),
+            ty::Ref(_, _, Mutability::Mut) | ty::RawPtr(..) => TriBool::False,
+            ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
+                found | self.contains_shared_output_parameter(ty, parameter, visited)
+            }),
+            ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) => {
+                self.contains_shared_output_parameter(*element, parameter, visited)
+            },
+            ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
+            ty::Adt(_, args) => args
+                .iter()
+                .filter_map(|arg| arg.as_type())
+                .fold(TriBool::False, |found, ty| {
+                    found | self.contains_shared_output_parameter(ty, parameter, visited)
+                }),
+            ty::Alias(..) => TriBool::Unknown,
+            _ => TriBool::False,
+        }
+    }
+
+    fn contains_parameter_dependency(
+        &self,
+        ty: Ty<'tcx>,
+        parameter: Ty<'tcx>,
+        visited: &mut FxHashSet<Ty<'tcx>>,
+    ) -> TriBool {
+        if ty == parameter {
+            return TriBool::True;
+        }
+        if !visited.insert(ty) {
+            return TriBool::False;
+        }
+        match ty.kind() {
+            ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
+                found | self.contains_parameter_dependency(ty, parameter, visited)
+            }),
+            ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) | ty::Ref(_, element, _) => {
+                self.contains_parameter_dependency(*element, parameter, visited)
+            },
+            ty::RawPtr(element, _) => self.contains_parameter_dependency(*element, parameter, visited),
+            ty::Adt(_, args) | ty::FnDef(_, args) => args
+                .iter()
+                .filter_map(|arg| arg.as_type())
+                .fold(TriBool::False, |found, ty| {
+                    found | self.contains_parameter_dependency(ty, parameter, visited)
+                }),
+            ty::Alias(..) => TriBool::Unknown,
+            _ => TriBool::False,
+        }
     }
 
     fn meta_arg(&self, term: &PredicateTerm, index: usize) -> Result<Symbol, UnsupportedItemPredicate> {

--- a/crates/rpl_match/src/item/predicate.rs
+++ b/crates/rpl_match/src/item/predicate.rs
@@ -254,6 +254,7 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
             ItemPredicate::TypeParameterMapsTo => self.type_parameter_maps_to(row, term),
             ItemPredicate::OwnsType => self.owns_type(row, term),
             ItemPredicate::IsSendIn => self.is_send_in(row, term),
+            ItemPredicate::IsSyncIn => self.is_sync_in(row, term),
         }
     }
 
@@ -400,6 +401,22 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
         // evaluator already carries incompleteness separately, so a future analysis can return
         // `Unknown` instead of treating every failed trait proof as `False`.
         let result = rpl_constraints::predicates::is_send(self.tcx, typing_env, ty);
+        Ok(EvalRows::decision(row, result.into()))
+    }
+
+    fn is_sync_in(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let ty = self.ty_arg(&row, term, 0)?;
+        let marker = self.impl_arg(&row, term, 1)?;
+        let typing_env = ty::TypingEnv::post_analysis(self.tcx, marker.to_def_id());
+
+        // Keep the same deliberately naive proof backend as `is_send_in`. The relational
+        // evaluator already preserves `Unknown`, so this can become a complete three-valued
+        // decision later without changing the predicate contract.
+        let result = rpl_constraints::predicates::is_sync(self.tcx, typing_env, ty);
         Ok(EvalRows::decision(row, result.into()))
     }
 

--- a/crates/rpl_match/src/item/predicate.rs
+++ b/crates/rpl_match/src/item/predicate.rs
@@ -27,17 +27,30 @@ struct TypeParameter<'tcx> {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AccessContext<'tcx> {
+    method: DefId,
+    resource: Ty<'tcx>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ItemValue<'tcx> {
     Adt(DefId),
     Impl(LocalDefId),
     TypeParameter(TypeParameter<'tcx>),
     Ty(Ty<'tcx>),
+    Access(AccessContext<'tcx>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SharedRefAccessKind {
     Exclusive,
     Concurrent,
+}
+
+#[derive(Debug)]
+struct AccessRows<'tcx> {
+    accesses: Vec<AccessContext<'tcx>>,
+    complete: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -263,6 +276,8 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
             ItemPredicate::OwnsType => self.owns_type(row, term),
             ItemPredicate::IsSendIn => self.is_send_in(row, term),
             ItemPredicate::IsSyncIn => self.is_sync_in(row, term),
+            ItemPredicate::IsSendForAccessIn => self.is_send_for_access_in(row, term),
+            ItemPredicate::IsSyncForAccessIn => self.is_sync_for_access_in(row, term),
             ItemPredicate::ResourceExclusivelyAccessibleFromSharedRefIn => {
                 self.resource_accessible_from_shared_ref_in(row, term, SharedRefAccessKind::Exclusive)
             },
@@ -440,27 +455,74 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
         term: &PredicateTerm,
         kind: SharedRefAccessKind,
     ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
-        let output = self.meta_arg(term, 0)?;
-        let wrapper = self.adt_arg(&row, term, 1)?;
-        let parameter = self.type_parameter_arg(&row, term, 2)?;
-        let mapped = self.ty_arg(&row, term, 3)?;
-        let marker = self.impl_arg(&row, term, 4)?;
+        let access_output = self.meta_arg(term, 0)?;
+        let resource_output = self.meta_arg(term, 1)?;
+        let wrapper = self.adt_arg(&row, term, 2)?;
+        let parameter = self.type_parameter_arg(&row, term, 3)?;
+        let mapped = self.ty_arg(&row, term, 4)?;
+        let marker = self.impl_arg(&row, term, 5)?;
 
         if parameter.owner != wrapper || !self.marker_maps_parameter_to(marker, parameter, mapped) {
             return Ok(EvalRows::empty());
         }
 
         // Phase one recognizes direct safe `&self` signatures and uses the matched type
-        // argument as the resource. The public relation is intentionally broader: a future
-        // implementation may emit projected or carrier types after analyzing method bodies,
-        // guards, trait APIs, and specialized substitutions.
-        match self.shared_ref_access_kind(wrapper, parameter, kind) {
-            TriBool::True => Ok(row
-                .bind(output, ItemValue::Ty(mapped))
-                .map_or_else(EvalRows::empty, EvalRows::one)),
-            TriBool::False => Ok(EvalRows::empty()),
-            TriBool::Unknown => Ok(EvalRows::unknown()),
+        // argument as the resource. Each emitted access retains its method-specific typing
+        // environment, so later predicates do not join evidence from unrelated APIs. The public
+        // relation is intentionally broader: a future implementation may emit projected or
+        // carrier types after analyzing method bodies, guards, trait APIs, and specialized
+        // substitutions.
+        let access_rows = self.shared_ref_accesses(wrapper, parameter, kind);
+        let mut rows = Vec::new();
+        for access in access_rows.accesses {
+            let Some(row) = row.clone().bind(access_output, ItemValue::Access(access)) else {
+                continue;
+            };
+            if let Some(row) = row.bind(resource_output, ItemValue::Ty(mapped)) {
+                rows.push(row);
+            }
         }
+        Ok(EvalRows {
+            rows,
+            complete: access_rows.complete,
+        })
+    }
+
+    fn is_send_for_access_in(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        self.trait_for_access_in(row, term, rpl_constraints::predicates::is_send)
+    }
+
+    fn is_sync_for_access_in(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        self.trait_for_access_in(row, term, rpl_constraints::predicates::is_sync)
+    }
+
+    fn trait_for_access_in(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        prove: impl Fn(TyCtxt<'tcx>, ty::TypingEnv<'tcx>, Ty<'tcx>) -> bool,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let resource = self.ty_arg(&row, term, 0)?;
+        let access = self.access_arg(&row, term, 1)?;
+        let marker = self.impl_arg(&row, term, 2)?;
+
+        // This first backend accepts a proof from either side of the correlated access:
+        // bounds on the unsafe marker impl constrain its mapped resource, while bounds on the
+        // method constrain the resource as named by that inherent impl. A complete evaluator can
+        // replace this with one instantiated combined environment without changing the surface
+        // predicate or the access correlation key.
+        let marker_env = ty::TypingEnv::post_analysis(self.tcx, marker.to_def_id());
+        let access_env = ty::TypingEnv::post_analysis(self.tcx, access.method);
+        let result = prove(self.tcx, marker_env, resource) || prove(self.tcx, access_env, access.resource);
+        Ok(EvalRows::decision(row, result.into()))
     }
 
     fn marker_maps_parameter_to(&self, marker: LocalDefId, parameter: TypeParameter<'tcx>, mapped: Ty<'tcx>) -> bool {
@@ -478,13 +540,14 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
                 .is_some_and(|ty| ty == mapped)
     }
 
-    fn shared_ref_access_kind(
+    fn shared_ref_accesses(
         &self,
         wrapper: DefId,
         parameter: TypeParameter<'tcx>,
         kind: SharedRefAccessKind,
-    ) -> TriBool {
-        let mut result = TriBool::False;
+    ) -> AccessRows<'tcx> {
+        let mut accesses = Vec::new();
+        let mut complete = true;
         for &impl_def_id in self.tcx.inherent_impls(wrapper).iter() {
             let impl_self_ty = self.tcx.type_of(impl_def_id).instantiate_identity();
             let ty::Adt(adt, args) = *impl_self_ty.kind() else {
@@ -494,13 +557,13 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
                 continue;
             }
             let Some(impl_parameter) = args.get(parameter.index as usize).and_then(|arg| arg.as_type()) else {
-                result = result | TriBool::Unknown;
+                complete = false;
                 continue;
             };
             if !matches!(impl_parameter.kind(), ty::Param(_)) {
                 // Specialized inherent impls need unification with the matched marker impl. Keep
                 // this incomplete rather than joining evidence from incompatible substitutions.
-                result = result | TriBool::Unknown;
+                complete = false;
                 continue;
             }
 
@@ -523,26 +586,30 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
                 let method_result = match kind {
                     SharedRefAccessKind::Exclusive => {
                         arguments.iter().copied().fold(TriBool::False, |found, ty| {
-                            found | self.contains_owned_parameter(ty, impl_parameter, &mut FxHashSet::default())
-                        }) | self.contains_exclusive_output_parameter(
+                            found | Self::contains_owned_parameter(ty, impl_parameter, &mut FxHashSet::default())
+                        }) | Self::contains_exclusive_output_parameter(
                             signature.output(),
                             impl_parameter,
                             &mut FxHashSet::default(),
                         )
                     },
-                    SharedRefAccessKind::Concurrent => self.contains_shared_output_parameter(
+                    SharedRefAccessKind::Concurrent => Self::contains_shared_output_parameter(
                         signature.output(),
                         impl_parameter,
                         &mut FxHashSet::default(),
                     ),
                 };
-                result = result | method_result;
-                if result == TriBool::True {
-                    return result;
+                match method_result {
+                    TriBool::True => accesses.push(AccessContext {
+                        method,
+                        resource: impl_parameter,
+                    }),
+                    TriBool::False => {},
+                    TriBool::Unknown => complete = false,
                 }
             }
         }
-        result
+        AccessRows { accesses, complete }
     }
 
     fn is_direct_shared_receiver(&self, receiver: Ty<'tcx>, wrapper: DefId) -> bool {
@@ -552,12 +619,7 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
         matches!(self_ty.kind(), ty::Adt(adt, _) if adt.did() == wrapper)
     }
 
-    fn contains_owned_parameter(
-        &self,
-        ty: Ty<'tcx>,
-        parameter: Ty<'tcx>,
-        visited: &mut FxHashSet<Ty<'tcx>>,
-    ) -> TriBool {
+    fn contains_owned_parameter(ty: Ty<'tcx>, parameter: Ty<'tcx>, visited: &mut FxHashSet<Ty<'tcx>>) -> TriBool {
         if ty == parameter {
             return TriBool::True;
         }
@@ -566,17 +628,17 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
         }
         match ty.kind() {
             ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
-                found | self.contains_owned_parameter(ty, parameter, visited)
+                found | Self::contains_owned_parameter(ty, parameter, visited)
             }),
             ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) => {
-                self.contains_owned_parameter(*element, parameter, visited)
+                Self::contains_owned_parameter(*element, parameter, visited)
             },
             ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
             ty::Adt(_, args) => args
                 .iter()
                 .filter_map(|arg| arg.as_type())
                 .fold(TriBool::False, |found, ty| {
-                    found | self.contains_owned_parameter(ty, parameter, visited)
+                    found | Self::contains_owned_parameter(ty, parameter, visited)
                 }),
             ty::Alias(..) => TriBool::Unknown,
             ty::Ref(..) | ty::RawPtr(..) | ty::FnDef(..) | ty::FnPtr(..) => TriBool::False,
@@ -585,7 +647,6 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
     }
 
     fn contains_exclusive_output_parameter(
-        &self,
         ty: Ty<'tcx>,
         parameter: Ty<'tcx>,
         visited: &mut FxHashSet<Ty<'tcx>>,
@@ -597,20 +658,20 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
             return TriBool::False;
         }
         match ty.kind() {
-            ty::Ref(_, referent, Mutability::Mut) => self.contains_parameter_dependency(*referent, parameter, visited),
+            ty::Ref(_, referent, Mutability::Mut) => Self::contains_parameter_dependency(*referent, parameter, visited),
             ty::Ref(_, _, Mutability::Not) | ty::RawPtr(..) => TriBool::False,
             ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
-                found | self.contains_exclusive_output_parameter(ty, parameter, visited)
+                found | Self::contains_exclusive_output_parameter(ty, parameter, visited)
             }),
             ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) => {
-                self.contains_exclusive_output_parameter(*element, parameter, visited)
+                Self::contains_exclusive_output_parameter(*element, parameter, visited)
             },
             ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
             ty::Adt(_, args) => args
                 .iter()
                 .filter_map(|arg| arg.as_type())
                 .fold(TriBool::False, |found, ty| {
-                    self.contains_exclusive_output_parameter(ty, parameter, visited) | found
+                    Self::contains_exclusive_output_parameter(ty, parameter, visited) | found
                 }),
             ty::Alias(..) => TriBool::Unknown,
             ty::FnDef(..) | ty::FnPtr(..) => TriBool::False,
@@ -619,7 +680,6 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
     }
 
     fn contains_shared_output_parameter(
-        &self,
         ty: Ty<'tcx>,
         parameter: Ty<'tcx>,
         visited: &mut FxHashSet<Ty<'tcx>>,
@@ -628,32 +688,27 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
             return TriBool::False;
         }
         match ty.kind() {
-            ty::Ref(_, referent, Mutability::Not) => self.contains_parameter_dependency(*referent, parameter, visited),
+            ty::Ref(_, referent, Mutability::Not) => Self::contains_parameter_dependency(*referent, parameter, visited),
             ty::Ref(_, _, Mutability::Mut) | ty::RawPtr(..) => TriBool::False,
             ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
-                found | self.contains_shared_output_parameter(ty, parameter, visited)
+                found | Self::contains_shared_output_parameter(ty, parameter, visited)
             }),
             ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) => {
-                self.contains_shared_output_parameter(*element, parameter, visited)
+                Self::contains_shared_output_parameter(*element, parameter, visited)
             },
             ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
             ty::Adt(_, args) => args
                 .iter()
                 .filter_map(|arg| arg.as_type())
                 .fold(TriBool::False, |found, ty| {
-                    found | self.contains_shared_output_parameter(ty, parameter, visited)
+                    found | Self::contains_shared_output_parameter(ty, parameter, visited)
                 }),
             ty::Alias(..) => TriBool::Unknown,
             _ => TriBool::False,
         }
     }
 
-    fn contains_parameter_dependency(
-        &self,
-        ty: Ty<'tcx>,
-        parameter: Ty<'tcx>,
-        visited: &mut FxHashSet<Ty<'tcx>>,
-    ) -> TriBool {
+    fn contains_parameter_dependency(ty: Ty<'tcx>, parameter: Ty<'tcx>, visited: &mut FxHashSet<Ty<'tcx>>) -> TriBool {
         if ty == parameter {
             return TriBool::True;
         }
@@ -662,18 +717,31 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
         }
         match ty.kind() {
             ty::Tuple(types) => types.iter().fold(TriBool::False, |found, ty| {
-                found | self.contains_parameter_dependency(ty, parameter, visited)
+                found | Self::contains_parameter_dependency(ty, parameter, visited)
             }),
             ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) | ty::Ref(_, element, _) => {
-                self.contains_parameter_dependency(*element, parameter, visited)
+                Self::contains_parameter_dependency(*element, parameter, visited)
             },
-            ty::RawPtr(element, _) => self.contains_parameter_dependency(*element, parameter, visited),
-            ty::Adt(_, args) | ty::FnDef(_, args) => args
-                .iter()
-                .filter_map(|arg| arg.as_type())
-                .fold(TriBool::False, |found, ty| {
-                    found | self.contains_parameter_dependency(ty, parameter, visited)
-                }),
+            // Merely sharing storage for a raw pointer or PhantomData does not provide a safe
+            // path to the pointed-to or marker type.
+            ty::RawPtr(..) => TriBool::False,
+            ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
+            ty::Adt(_, args) => {
+                let dependency = args
+                    .iter()
+                    .filter_map(|arg| arg.as_type())
+                    .fold(TriBool::False, |found, ty| {
+                        found | Self::contains_parameter_dependency(ty, parameter, visited)
+                    });
+                if dependency == TriBool::False {
+                    TriBool::False
+                } else {
+                    // A reference to an arbitrary carrier is not automatically a safe reference
+                    // to its generic argument. Body/API analysis is needed to decide projection.
+                    TriBool::Unknown
+                }
+            },
+            ty::FnDef(..) | ty::FnPtr(..) => TriBool::False,
             ty::Alias(..) => TriBool::Unknown,
             _ => TriBool::False,
         }
@@ -743,6 +811,18 @@ impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
             ItemValue::TypeParameter(parameter) => Ok(parameter.ty),
             ItemValue::Ty(ty) => Ok(ty),
             _ => Err(self.error(term, &format!("argument {index} is not a type"))),
+        }
+    }
+
+    fn access_arg(
+        &self,
+        row: &ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        index: usize,
+    ) -> Result<AccessContext<'tcx>, UnsupportedItemPredicate> {
+        match self.value_arg(row, term, index)? {
+            ItemValue::Access(access) => Ok(access),
+            _ => Err(self.error(term, &format!("argument {index} is not an access"))),
         }
     }
 

--- a/crates/rpl_match/src/item/predicate.rs
+++ b/crates/rpl_match/src/item/predicate.rs
@@ -1,0 +1,479 @@
+use rpl_constraints::Constraints;
+use rpl_constraints::predicates::{
+    ItemPredicate, PredicateArg, PredicateClause, PredicateConjunction, PredicateKind, PredicateTerm,
+};
+use rpl_constraints::tribool::TriBool;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::Symbol;
+
+use super::ItemMatched;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsupportedItemPredicate {
+    pub name: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TypeParameter<'tcx> {
+    owner: DefId,
+    def_id: DefId,
+    index: u32,
+    ty: Ty<'tcx>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ItemValue<'tcx> {
+    Adt(DefId),
+    Impl(LocalDefId),
+    TypeParameter(TypeParameter<'tcx>),
+    Ty(Ty<'tcx>),
+}
+
+#[derive(Clone, Debug, Default)]
+struct ItemBindings<'tcx> {
+    values: FxHashMap<Symbol, ItemValue<'tcx>>,
+}
+
+impl<'tcx> ItemBindings<'tcx> {
+    fn seed(matched: &ItemMatched<'tcx>) -> Self {
+        let mut values = FxHashMap::default();
+        values.extend(
+            matched
+                .adts
+                .iter()
+                .map(|(name, def_id)| (*name, ItemValue::Adt(*def_id))),
+        );
+        values.extend(
+            matched
+                .impls
+                .iter()
+                .map(|(name, def_id)| (*name, ItemValue::Impl(*def_id))),
+        );
+        Self { values }
+    }
+
+    fn get(&self, name: Symbol) -> Option<ItemValue<'tcx>> {
+        self.values.get(&name).copied()
+    }
+
+    fn bind(mut self, name: Symbol, value: ItemValue<'tcx>) -> Option<Self> {
+        match self.values.get(&name) {
+            Some(previous) if *previous != value => None,
+            Some(_) => Some(self),
+            None => {
+                self.values.insert(name, value);
+                Some(self)
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EvalRows<'tcx> {
+    rows: Vec<ItemBindings<'tcx>>,
+    complete: bool,
+}
+
+impl<'tcx> EvalRows<'tcx> {
+    fn one(row: ItemBindings<'tcx>) -> Self {
+        Self {
+            rows: vec![row],
+            complete: true,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            rows: Vec::new(),
+            complete: true,
+        }
+    }
+
+    fn unknown() -> Self {
+        Self {
+            rows: Vec::new(),
+            complete: false,
+        }
+    }
+
+    fn decision(row: ItemBindings<'tcx>, result: TriBool) -> Self {
+        match result {
+            TriBool::True => Self::one(row),
+            TriBool::False => Self::empty(),
+            TriBool::Unknown => Self::unknown(),
+        }
+    }
+
+    fn truth(&self) -> TriBool {
+        if !self.rows.is_empty() {
+            TriBool::True
+        } else if self.complete {
+            TriBool::False
+        } else {
+            TriBool::Unknown
+        }
+    }
+}
+
+pub struct ItemPredicateEvaluator<'matched, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    matched: &'matched ItemMatched<'tcx>,
+}
+
+impl<'matched, 'tcx> ItemPredicateEvaluator<'matched, 'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, matched: &'matched ItemMatched<'tcx>) -> Self {
+        Self { tcx, matched }
+    }
+
+    #[instrument(level = "debug", skip(self, constraints), fields(root_impl = ?self.matched.root_impl), ret)]
+    pub fn evaluate(&self, constraints: Option<&Constraints>) -> Result<TriBool, UnsupportedItemPredicate> {
+        let Some(constraints) = constraints else {
+            return Ok(TriBool::True);
+        };
+        if constraints.has_attributes {
+            return Err(UnsupportedItemPredicate {
+                name: "<attribute>".to_string(),
+                reason: "attributes are not supported in item guards".to_string(),
+            });
+        }
+
+        let mut result = EvalRows::one(ItemBindings::seed(self.matched));
+        for conjunction in &constraints.preds {
+            result = self.evaluate_conjunction(result, conjunction)?;
+            if result.rows.is_empty() && result.complete {
+                break;
+            }
+        }
+        Ok(result.truth())
+    }
+
+    fn evaluate_conjunction(
+        &self,
+        mut input: EvalRows<'tcx>,
+        conjunction: &PredicateConjunction,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        for clause in &conjunction.clauses {
+            input = self.evaluate_clause(input, clause)?;
+            if input.rows.is_empty() && input.complete {
+                break;
+            }
+        }
+        Ok(input)
+    }
+
+    fn evaluate_clause(
+        &self,
+        input: EvalRows<'tcx>,
+        clause: &PredicateClause,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        if clause.terms.len() == 1 {
+            let term = &clause.terms[0];
+            let mut output = EvalRows {
+                rows: Vec::new(),
+                complete: input.complete,
+            };
+            for row in input.rows {
+                let result = self.evaluate_term(row, term)?;
+                output.rows.extend(result.rows);
+                output.complete &= result.complete;
+            }
+            return Ok(output);
+        }
+
+        // Meta checking restricts disjunctions to closed decision predicates, so a successful
+        // alternative keeps the original row and an unknown alternative matters only when none
+        // of the alternatives succeeds.
+        let mut output = EvalRows {
+            rows: Vec::new(),
+            complete: input.complete,
+        };
+        for row in input.rows {
+            let mut succeeded = false;
+            let mut complete = true;
+            for term in &clause.terms {
+                let result = self.evaluate_term(row.clone(), term)?;
+                if !result.rows.is_empty() {
+                    succeeded = true;
+                    break;
+                }
+                complete &= result.complete;
+            }
+            if succeeded {
+                output.rows.push(row);
+            } else {
+                output.complete &= complete;
+            }
+        }
+        Ok(output)
+    }
+
+    fn evaluate_term(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let positive = self.evaluate_positive_term(row.clone(), term)?;
+        if !term.is_neg {
+            return Ok(positive);
+        }
+        if !positive.rows.is_empty() {
+            Ok(EvalRows::empty())
+        } else if positive.complete {
+            Ok(EvalRows::one(row))
+        } else {
+            Ok(EvalRows::unknown())
+        }
+    }
+
+    fn evaluate_positive_term(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        match term.kind {
+            PredicateKind::Trivial(predicate) if term.args.is_empty() => {
+                Ok(EvalRows::decision(row, predicate().into()))
+            },
+            PredicateKind::Item(predicate) => self.evaluate_item_predicate(row, term, predicate),
+            _ => Err(self.error(term, "predicate is not supported by the item matcher")),
+        }
+    }
+
+    fn evaluate_item_predicate(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        predicate: ItemPredicate,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        match predicate {
+            ItemPredicate::HasTypeParameters => self.has_type_parameters(row, term),
+            ItemPredicate::TypeParameterOf => self.type_parameter_of(row, term),
+            ItemPredicate::TypeParameterMapsTo => self.type_parameter_maps_to(row, term),
+            ItemPredicate::OwnsType => self.owns_type(row, term),
+            ItemPredicate::IsSendIn => self.is_send_in(row, term),
+        }
+    }
+
+    fn has_type_parameters(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let wrapper = self.adt_arg(&row, term, 0)?;
+        let has_type_parameters = self
+            .tcx
+            .generics_of(wrapper)
+            .own_params
+            .iter()
+            .any(|param| matches!(param.kind, ty::GenericParamDefKind::Type { .. }));
+        Ok(EvalRows::decision(row, has_type_parameters.into()))
+    }
+
+    fn type_parameter_of(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let output = self.meta_arg(term, 0)?;
+        let wrapper = self.adt_arg(&row, term, 1)?;
+        let mut rows = Vec::new();
+        for param in self
+            .tcx
+            .generics_of(wrapper)
+            .own_params
+            .iter()
+            .filter(|param| matches!(param.kind, ty::GenericParamDefKind::Type { .. }))
+        {
+            let Some(param_ty) = self.tcx.mk_param_from_def(param).as_type() else {
+                continue;
+            };
+            let parameter = TypeParameter {
+                owner: wrapper,
+                def_id: param.def_id,
+                index: param.index,
+                ty: param_ty,
+            };
+            if let Some(row) = row.clone().bind(output, ItemValue::TypeParameter(parameter)) {
+                rows.push(row);
+            }
+        }
+        Ok(EvalRows { rows, complete: true })
+    }
+
+    fn type_parameter_maps_to(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let parameter = self.type_parameter_arg(&row, term, 0)?;
+        let output = self.meta_arg(term, 1)?;
+        let marker = self.impl_arg(&row, term, 2)?;
+        let trait_ref = self
+            .tcx
+            .impl_trait_ref(marker.to_def_id())
+            .ok_or_else(|| self.error(term, "impl binding does not name a trait impl"))?
+            .instantiate_identity();
+        let ty::Adt(adt, args) = *trait_ref.self_ty().kind() else {
+            return Ok(EvalRows::empty());
+        };
+        if adt.did() != parameter.owner {
+            return Ok(EvalRows::empty());
+        }
+        let Some(mapped) = args.get(parameter.index as usize).and_then(|arg| arg.as_type()) else {
+            return Ok(EvalRows::empty());
+        };
+        Ok(row
+            .bind(output, ItemValue::Ty(mapped))
+            .map_or_else(EvalRows::empty, EvalRows::one))
+    }
+
+    fn owns_type(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let wrapper = self.adt_arg(&row, term, 0)?;
+        let parameter = self.type_parameter_arg(&row, term, 1)?;
+        if wrapper != parameter.owner {
+            return Ok(EvalRows::empty());
+        }
+
+        // Deliberately naive ownership backend: follow by-value fields recursively, ignore
+        // PhantomData and non-owning pointer/reference edges, and preserve `Unknown` for aliases.
+        // More precise ownership analyses can replace this method without changing row planning.
+        let args = ty::GenericArgs::identity_for_item(self.tcx, wrapper);
+        let mut visited = FxHashSet::default();
+        let mut result = TriBool::False;
+        for field in self.tcx.adt_def(wrapper).all_fields() {
+            result = result | self.ty_owns_parameter(field.ty(self.tcx, args), parameter, &mut visited);
+            if result == TriBool::True {
+                break;
+            }
+        }
+        Ok(EvalRows::decision(row, result))
+    }
+
+    fn ty_owns_parameter(
+        &self,
+        ty: Ty<'tcx>,
+        parameter: TypeParameter<'tcx>,
+        visited: &mut FxHashSet<Ty<'tcx>>,
+    ) -> TriBool {
+        if !visited.insert(ty) {
+            return TriBool::False;
+        }
+        match ty.kind() {
+            ty::Param(param) => (param.index == parameter.index).into(),
+            ty::Tuple(types) => types.iter().fold(TriBool::False, |result, ty| {
+                result | self.ty_owns_parameter(ty, parameter, visited)
+            }),
+            ty::Array(element, _) | ty::Slice(element) | ty::Pat(element, _) => {
+                self.ty_owns_parameter(*element, parameter, visited)
+            },
+            ty::Adt(adt, _) if adt.is_phantom_data() => TriBool::False,
+            ty::Adt(adt, args) if adt.is_box() => args
+                .iter()
+                .find_map(|arg| arg.as_type())
+                .map_or(TriBool::Unknown, |ty| self.ty_owns_parameter(ty, parameter, visited)),
+            ty::Adt(adt, args) => adt.all_fields().fold(TriBool::False, |result, field| {
+                result | self.ty_owns_parameter(field.ty(self.tcx, args), parameter, visited)
+            }),
+            ty::Alias(..) => TriBool::Unknown,
+            ty::Ref(..) | ty::RawPtr(..) | ty::FnDef(..) | ty::FnPtr(..) => TriBool::False,
+            _ => TriBool::False,
+        }
+    }
+
+    fn is_send_in(
+        &self,
+        row: ItemBindings<'tcx>,
+        term: &PredicateTerm,
+    ) -> Result<EvalRows<'tcx>, UnsupportedItemPredicate> {
+        let ty = self.ty_arg(&row, term, 0)?;
+        let marker = self.impl_arg(&row, term, 1)?;
+        let typing_env = ty::TypingEnv::post_analysis(self.tcx, marker.to_def_id());
+
+        // This is the deliberately naive backend for the first implementation. The relational
+        // evaluator already carries incompleteness separately, so a future analysis can return
+        // `Unknown` instead of treating every failed trait proof as `False`.
+        let result = rpl_constraints::predicates::is_send(self.tcx, typing_env, ty);
+        Ok(EvalRows::decision(row, result.into()))
+    }
+
+    fn meta_arg(&self, term: &PredicateTerm, index: usize) -> Result<Symbol, UnsupportedItemPredicate> {
+        match term.args.get(index) {
+            Some(PredicateArg::MetaVar(name)) => Ok(*name),
+            _ => Err(self.error(term, &format!("argument {index} is not a metavariable"))),
+        }
+    }
+
+    fn value_arg(
+        &self,
+        row: &ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        index: usize,
+    ) -> Result<ItemValue<'tcx>, UnsupportedItemPredicate> {
+        let name = self.meta_arg(term, index)?;
+        row.get(name)
+            .ok_or_else(|| self.error(term, &format!("metavariable `{name}` is not bound")))
+    }
+
+    fn adt_arg(
+        &self,
+        row: &ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        index: usize,
+    ) -> Result<DefId, UnsupportedItemPredicate> {
+        match self.value_arg(row, term, index)? {
+            ItemValue::Adt(def_id) => Ok(def_id),
+            _ => Err(self.error(term, &format!("argument {index} is not an ADT"))),
+        }
+    }
+
+    fn impl_arg(
+        &self,
+        row: &ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        index: usize,
+    ) -> Result<LocalDefId, UnsupportedItemPredicate> {
+        match self.value_arg(row, term, index)? {
+            ItemValue::Impl(def_id) => Ok(def_id),
+            _ => Err(self.error(term, &format!("argument {index} is not an impl binding"))),
+        }
+    }
+
+    fn type_parameter_arg(
+        &self,
+        row: &ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        index: usize,
+    ) -> Result<TypeParameter<'tcx>, UnsupportedItemPredicate> {
+        match self.value_arg(row, term, index)? {
+            ItemValue::TypeParameter(parameter) => Ok(parameter),
+            _ => Err(self.error(term, &format!("argument {index} is not a type parameter"))),
+        }
+    }
+
+    fn ty_arg(
+        &self,
+        row: &ItemBindings<'tcx>,
+        term: &PredicateTerm,
+        index: usize,
+    ) -> Result<Ty<'tcx>, UnsupportedItemPredicate> {
+        match self.value_arg(row, term, index)? {
+            ItemValue::TypeParameter(parameter) => Ok(parameter.ty),
+            ItemValue::Ty(ty) => Ok(ty),
+            _ => Err(self.error(term, &format!("argument {index} is not a type"))),
+        }
+    }
+
+    fn error(&self, term: &PredicateTerm, reason: &str) -> UnsupportedItemPredicate {
+        UnsupportedItemPredicate {
+            name: term.name.clone(),
+            reason: reason.to_string(),
+        }
+    }
+}

--- a/crates/rpl_match/src/lib.rs
+++ b/crates/rpl_match/src/lib.rs
@@ -35,6 +35,7 @@ mod adt;
 mod counted;
 mod fns;
 pub mod graph; // FIXME: visibility
+pub mod item;
 pub mod matches; // FIXME: visibility
 pub mod mir; // FIXME: visibility
 mod place;

--- a/crates/rpl_match/src/predicate_evaluator.rs
+++ b/crates/rpl_match/src/predicate_evaluator.rs
@@ -302,6 +302,7 @@ impl<'e, 'm, 'tcx> PredicateEvaluator<'e, 'm, 'tcx> {
                             Ok(PredicateArgInstance::Place(place_var))
                         },
                         MetaVariable::AdtPat(_, _) => Err(format!("meta_var `{}` is an ADT pattern", name)),
+                        MetaVariable::Access(_, _) => Err(format!("meta_var `{}` is an item access", name)),
                     }
                 } else if let Some(idx) = self.symbol_table.inner.try_get_local_idx(name.as_str()) {
                     let local = pat::Local::from_usize(idx);

--- a/crates/rpl_match/src/predicate_evaluator.rs
+++ b/crates/rpl_match/src/predicate_evaluator.rs
@@ -218,6 +218,9 @@ impl<'e, 'm, 'tcx> PredicateEvaluator<'e, 'm, 'tcx> {
             },
             PredicateKind::FlowsTo => self.eval_flows_to(&arg_instance),
             PredicateKind::MayPanic => self.eval_may_panic(&arg_instance),
+            PredicateKind::Item(predicate) => {
+                unreachable!("item predicate {predicate:?} reached the MIR predicate evaluator")
+            },
         };
         if term.is_neg { !result } else { result }
     }

--- a/crates/rpl_match/src/session/inner.rs
+++ b/crates/rpl_match/src/session/inner.rs
@@ -26,6 +26,10 @@ impl<'a, 'pcx, 'tcx> MatchSession<'a, 'pcx, 'tcx> {
         index: &CrateItemIndex,
         rust_items: &'pcx pat::RustItems<'pcx>,
     ) -> Vec<SessionResult<'tcx>> {
+        // Item guards need ADT/impl bindings from the item-rooted matcher.
+        if !rust_items.legacy_function_matching_enabled() {
+            return Vec::new();
+        }
         let (fn_slots, adt_slots) = collect_slot_descs(rust_items);
 
         if fn_slots.is_empty() && adt_slots.is_empty() {

--- a/crates/rpl_match/src/session/slot.rs
+++ b/crates/rpl_match/src/session/slot.rs
@@ -170,7 +170,7 @@ pub fn collect_slot_descs<'pcx>(
         .collect();
 
     let mut next_idx = fn_slots.len();
-    for impl_pat in rust_items.impls.values() {
+    for impl_pat in rust_items.legacy_impl_for_function_matching().into_iter() {
         for fn_pat in impl_pat.fns.values() {
             fn_slots.push(FnSlotDesc {
                 slot: MatchSlot::Fn(next_idx),

--- a/crates/rpl_meta/src/check.rs
+++ b/crates/rpl_meta/src/check.rs
@@ -5,13 +5,13 @@ use impls::CheckImplCtxt;
 use parser::generics::{Choice2, Choice3, Choice4, Choice5, Choice6, Choice9, Choice12, Choice14};
 use parser::{SpanWrapper, pairs};
 use rpl_constraints::predicates::{PredicateConjunction, PredicateError};
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 
 use crate::check::lang_item::is_lang_item;
 use crate::context::MetaContext;
 use crate::symbol_table::{
-    AdtPatType, AdtPats, EnumInner, FnInner, GetType as _, ImplInner, MetaVariable, NonLocalMetaSymTab, SymbolTable,
-    Variant, WithMetaTable, WithPath, ident_is_primitive,
+    AdtPatType, AdtPats, EnumInner, FnInner, GetType as _, ImplInner, ItemBindingType, MetaVariable,
+    NonLocalMetaSymTab, SymbolTable, Variant, WithMetaTable, WithPath, ident_is_primitive,
 };
 use crate::utils::{Path, Record};
 use crate::{RPLMetaError, collect_elems_separated_by_comma};
@@ -141,7 +141,9 @@ impl<'i> CheckCtxt<'i> {
                 let item = rust_item_or_patt_operation.RustItemWithConstraint();
                 let items = rust_item_or_patt_operation.RustItemsWithConstraint();
                 let rust_items = if let Some(items) = items {
-                    items.get_matched().1.iter_matched().collect::<Vec<_>>()
+                    let (_, rust_items, _, where_block) = items.get_matched();
+                    self.check_item_where_block(mctx, where_block.as_ref());
+                    rust_items.iter_matched().collect::<Vec<_>>()
                 } else {
                     // unwrap here is safe because the `RustItem` or `RustItems` is not `None`
                     vec![item.unwrap()]
@@ -152,18 +154,109 @@ impl<'i> CheckCtxt<'i> {
     }
 
     fn check_rust_items(&mut self, mctx: &MetaContext<'i>, rust_items: Vec<&'i pairs::RustItemWithConstraint<'i>>) {
-        // FIXME: check the constraints in meta_pass
-        let rust_items = rust_items
-            .into_iter()
-            .map(|item| item.get_matched().1)
-            .collect::<Vec<_>>();
-        for rust_item in rust_items {
+        for item in rust_items {
+            let (_, rust_item, where_block) = item.get_matched();
+            self.check_where_block(mctx, where_block.as_ref());
             match rust_item.deref() {
                 Choice4::_0(rust_fn) => self.check_fn(mctx, rust_fn),
                 Choice4::_1(rust_struct) => self.check_struct(mctx, rust_struct),
                 Choice4::_2(rust_enum) => self.check_enum(mctx, rust_enum),
                 Choice4::_3(rust_impl) => self.check_impl(mctx, rust_impl),
             }
+        }
+    }
+
+    fn check_where_block(&mut self, mctx: &MetaContext<'i>, where_block: Option<&'i pairs::WhereBlock<'i>>) {
+        let Some(constraints) = where_block.and_then(|where_block| where_block.ConstraintsSeparatedByComma()) else {
+            return;
+        };
+        let (first, following, _) = constraints.get_matched();
+        std::iter::once(first)
+            .chain(following.iter_matched().map(|constraint| constraint.get_matched().1))
+            .filter_map(|constraint| constraint.PredicateConjunction())
+            .for_each(|predicates| self.check_pred_conjunction_opt(mctx, Some(predicates)));
+    }
+
+    fn check_item_where_block(&mut self, mctx: &MetaContext<'i>, where_block: Option<&'i pairs::WhereBlock<'i>>) {
+        let Some(constraints) = where_block.and_then(|where_block| where_block.ConstraintsSeparatedByComma()) else {
+            return;
+        };
+        let (first, following, _) = constraints.get_matched();
+        for constraint in
+            std::iter::once(first).chain(following.iter_matched().map(|constraint| constraint.get_matched().1))
+        {
+            match constraint.deref() {
+                Choice2::_0(attribute) => {
+                    self.errors.push(
+                        PredicateError::UnsupportedItemGuardAttribute {
+                            span: SpanWrapper::new(attribute.span, mctx.get_active_path()),
+                        }
+                        .into(),
+                    );
+                },
+                Choice2::_1(predicates) => self.check_item_pred_conjunction(mctx, predicates),
+            }
+        }
+    }
+
+    fn check_item_pred_conjunction(&mut self, mctx: &MetaContext<'i>, predicates: &'i pairs::PredicateConjunction<'i>) {
+        let (first, following) = predicates.get_matched();
+        std::iter::once(first)
+            .chain(
+                following
+                    .iter_matched()
+                    .map(|and_predicate| and_predicate.get_matched().1),
+            )
+            .for_each(|predicate| self.check_item_pred_clause(mctx, predicate));
+    }
+
+    fn check_item_pred_clause(&mut self, mctx: &MetaContext<'i>, predicate: &'i pairs::PredicateClause<'i>) {
+        match predicate.deref() {
+            Choice2::_0(predicate) => self.check_item_pred_literal(mctx, predicate),
+            Choice2::_1(predicates) => {
+                let (_, first, following, _) = predicates.get_matched();
+                std::iter::once(first)
+                    .chain(
+                        following
+                            .iter_matched()
+                            .map(|or_predicate| or_predicate.get_matched().1),
+                    )
+                    .for_each(|predicate| self.check_item_pred_literal(mctx, predicate));
+            },
+        }
+    }
+
+    fn check_item_pred_literal(&mut self, mctx: &MetaContext<'i>, predicate: &'i pairs::PredicateTerm<'i>) {
+        let predicate = match predicate.deref() {
+            Choice2::_0(predicate) => predicate,
+            Choice2::_1(predicate) => predicate.get_matched().1,
+        };
+        let (name, _, args, _) = predicate.get_matched();
+        let name = name.span.as_str();
+        if !rpl_constraints::predicates::ALL_PREDICATES.contains(&name) {
+            self.errors.push(
+                PredicateError::InvalidPredicate {
+                    pred: name,
+                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
+                }
+                .into(),
+            );
+        } else if !matches!(name, "true" | "false") {
+            self.errors.push(
+                PredicateError::UnsupportedItemGuardPredicate {
+                    pred: name,
+                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
+                }
+                .into(),
+            );
+        } else if args.is_some() {
+            self.errors.push(
+                PredicateError::ItemGuardPredicateTakesNoArgs {
+                    pred: name,
+                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
+                }
+                .into(),
+            );
         }
     }
 
@@ -214,6 +307,13 @@ impl<'i> CheckCtxt<'i> {
     }
 
     fn check_impl(&mut self, mctx: &MetaContext<'i>, rust_impl: &'i pairs::Impl<'i>) {
+        if let Some(impl_kind) = rust_impl.ImplKind() {
+            self.check_impl_trait_path(mctx, impl_kind.get_matched().0);
+        }
+        if let Some(binding) = rust_impl.ItemBinding() {
+            self.symbol_table
+                .add_item_binding(mctx, binding.MetaVariable(), ItemBindingType::Impl, &mut self.errors);
+        }
         let meta_vars = self.symbol_table.meta_vars.clone();
         let impl_def = self.symbol_table.add_impl(mctx, rust_impl, &mut self.errors);
         if let Some((impl_def, imports, adt_pats)) = impl_def {
@@ -225,6 +325,42 @@ impl<'i> CheckCtxt<'i> {
                 errors: &mut self.errors,
             }
             .check_impl(mctx, rust_impl);
+        }
+    }
+
+    fn check_impl_trait_path(&mut self, mctx: &MetaContext<'i>, path: &'i pairs::Path<'i>) {
+        let source = path.span.as_str().trim();
+        let span = || SpanWrapper::new(path.span, mctx.get_active_path());
+        let mut resolved: Path<'i> = path.into();
+
+        let mut used = FxHashSet::default();
+        while let Some(ident) = resolved.leading_ident()
+            && let Some(mapped) = self.symbol_table.imports.get(ident.span.as_str()).copied()
+        {
+            if !used.insert(mapped) {
+                self.errors.push(RPLMetaError::CyclicImplTraitPathImport {
+                    value: source,
+                    span: span(),
+                });
+                return;
+            }
+            resolved = resolved.replace_leading_ident(Path::from(mapped));
+        }
+
+        if resolved.segments.iter().any(|(_, args)| !args.is_empty()) {
+            self.errors
+                .push(RPLMetaError::UnsupportedImplTraitGenericArguments { span: span() });
+            return;
+        }
+
+        let is_local = resolved
+            .leading
+            .is_some_and(|leading| leading.get_matched().0.is_some());
+        if !is_local && resolved.segments.len() < 2 {
+            self.errors.push(RPLMetaError::UnqualifiedImplTraitPath {
+                value: source,
+                span: span(),
+            });
         }
     }
 }
@@ -802,10 +938,14 @@ struct CheckVariantCtxt<'i, 'r> {
 
 impl<'i> CheckVariantCtxt<'i, '_> {
     fn check_struct(mut self, mctx: &MetaContext<'i>, struct_: &'i pairs::Struct<'i>) {
-        let (_, _, _, _, fields, _) = struct_.get_matched();
+        let (_, _, _, _, _, fields, _) = struct_.get_matched();
         if let Some(fields) = fields {
-            let fields = collect_elems_separated_by_comma!(fields).collect::<Vec<_>>();
-            self.check_fields(mctx, fields.into_iter());
+            if let Some(fields) = fields.NonExhaustiveFields() {
+                self.check_fields(mctx, fields.Field().into_iter());
+            } else if let Some(fields) = fields.FieldsSeparatedByComma() {
+                let fields = collect_elems_separated_by_comma!(fields).collect::<Vec<_>>();
+                self.check_fields(mctx, fields.into_iter());
+            }
         }
     }
 

--- a/crates/rpl_meta/src/check.rs
+++ b/crates/rpl_meta/src/check.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use impls::CheckImplCtxt;
 use parser::generics::{Choice2, Choice3, Choice4, Choice5, Choice6, Choice9, Choice12, Choice14};
 use parser::{SpanWrapper, pairs};
-use rpl_constraints::predicates::{PredicateConjunction, PredicateError};
+use rpl_constraints::predicates::{ItemPredicateArgMode, PredicateConjunction, PredicateError, item_predicate_spec};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 
 use crate::check::lang_item::is_lang_item;
@@ -117,7 +117,15 @@ impl<'i> CheckCtxt<'i> {
             Choice2::_1(pred) => pred.get_matched().1,
         };
         let pred_name = pred.get_matched().0.span.as_str();
-        if !rpl_constraints::predicates::ALL_PREDICATES.contains(&pred_name) {
+        if item_predicate_spec(pred_name).is_some_and(|spec| spec.predicate.is_some()) {
+            self.errors.push(
+                PredicateError::ItemPredicateOutsideItemGuard {
+                    pred: pred_name,
+                    span: SpanWrapper::new(pred.span, mctx.get_active_path()),
+                }
+                .into(),
+            );
+        } else if !rpl_constraints::predicates::ALL_PREDICATES.contains(&pred_name) {
             self.errors.push(
                 PredicateError::InvalidPredicate {
                     pred: pred_name,
@@ -140,15 +148,14 @@ impl<'i> CheckCtxt<'i> {
             _ => {
                 let item = rust_item_or_patt_operation.RustItemWithConstraint();
                 let items = rust_item_or_patt_operation.RustItemsWithConstraint();
-                let rust_items = if let Some(items) = items {
+                if let Some(items) = items {
                     let (_, rust_items, _, where_block) = items.get_matched();
+                    self.check_rust_items(mctx, rust_items.iter_matched().collect());
                     self.check_item_where_block(mctx, where_block.as_ref());
-                    rust_items.iter_matched().collect::<Vec<_>>()
                 } else {
                     // unwrap here is safe because the `RustItem` or `RustItems` is not `None`
-                    vec![item.unwrap()]
-                };
-                self.check_rust_items(mctx, rust_items)
+                    self.check_rust_items(mctx, vec![item.unwrap()]);
+                }
             },
         }
     }
@@ -181,6 +188,13 @@ impl<'i> CheckCtxt<'i> {
         let Some(constraints) = where_block.and_then(|where_block| where_block.ConstraintsSeparatedByComma()) else {
             return;
         };
+        let mut bound: FxHashSet<&'i str> = self
+            .symbol_table
+            .meta_vars
+            .adt_vars()
+            .filter(|name| self.symbol_table.get_adt(name).is_some())
+            .collect();
+        bound.extend(self.symbol_table.item_bindings().map(|(name, _)| name));
         let (first, following, _) = constraints.get_matched();
         for constraint in
             std::iter::once(first).chain(following.iter_matched().map(|constraint| constraint.get_matched().1))
@@ -194,12 +208,17 @@ impl<'i> CheckCtxt<'i> {
                         .into(),
                     );
                 },
-                Choice2::_1(predicates) => self.check_item_pred_conjunction(mctx, predicates),
+                Choice2::_1(predicates) => self.check_item_pred_conjunction(mctx, predicates, &mut bound),
             }
         }
     }
 
-    fn check_item_pred_conjunction(&mut self, mctx: &MetaContext<'i>, predicates: &'i pairs::PredicateConjunction<'i>) {
+    fn check_item_pred_conjunction(
+        &mut self,
+        mctx: &MetaContext<'i>,
+        predicates: &'i pairs::PredicateConjunction<'i>,
+        bound: &mut FxHashSet<&'i str>,
+    ) {
         let (first, following) = predicates.get_matched();
         std::iter::once(first)
             .chain(
@@ -207,12 +226,17 @@ impl<'i> CheckCtxt<'i> {
                     .iter_matched()
                     .map(|and_predicate| and_predicate.get_matched().1),
             )
-            .for_each(|predicate| self.check_item_pred_clause(mctx, predicate));
+            .for_each(|predicate| self.check_item_pred_clause(mctx, predicate, bound));
     }
 
-    fn check_item_pred_clause(&mut self, mctx: &MetaContext<'i>, predicate: &'i pairs::PredicateClause<'i>) {
+    fn check_item_pred_clause(
+        &mut self,
+        mctx: &MetaContext<'i>,
+        predicate: &'i pairs::PredicateClause<'i>,
+        bound: &mut FxHashSet<&'i str>,
+    ) {
         match predicate.deref() {
-            Choice2::_0(predicate) => self.check_item_pred_literal(mctx, predicate),
+            Choice2::_0(predicate) => self.check_item_pred_literal(mctx, predicate, bound, false),
             Choice2::_1(predicates) => {
                 let (_, first, following, _) = predicates.get_matched();
                 std::iter::once(first)
@@ -221,42 +245,140 @@ impl<'i> CheckCtxt<'i> {
                             .iter_matched()
                             .map(|or_predicate| or_predicate.get_matched().1),
                     )
-                    .for_each(|predicate| self.check_item_pred_literal(mctx, predicate));
+                    .for_each(|predicate| {
+                        self.check_item_pred_literal(mctx, predicate, &mut bound.clone(), true);
+                    });
             },
         }
     }
 
-    fn check_item_pred_literal(&mut self, mctx: &MetaContext<'i>, predicate: &'i pairs::PredicateTerm<'i>) {
-        let predicate = match predicate.deref() {
-            Choice2::_0(predicate) => predicate,
-            Choice2::_1(predicate) => predicate.get_matched().1,
+    fn check_item_pred_literal(
+        &mut self,
+        mctx: &MetaContext<'i>,
+        predicate: &'i pairs::PredicateTerm<'i>,
+        bound: &mut FxHashSet<&'i str>,
+        in_disjunction: bool,
+    ) {
+        let (predicate, is_negated) = match predicate.deref() {
+            Choice2::_0(predicate) => (predicate, false),
+            Choice2::_1(predicate) => (predicate.get_matched().1, true),
         };
         let (name, _, args, _) = predicate.get_matched();
         let name = name.span.as_str();
-        if !rpl_constraints::predicates::ALL_PREDICATES.contains(&name) {
-            self.errors.push(
-                PredicateError::InvalidPredicate {
-                    pred: name,
-                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
-                }
-                .into(),
-            );
-        } else if !matches!(name, "true" | "false") {
-            self.errors.push(
+        let Some(spec) = item_predicate_spec(name) else {
+            let error = if rpl_constraints::predicates::ALL_PREDICATES.contains(&name) {
                 PredicateError::UnsupportedItemGuardPredicate {
                     pred: name,
                     span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
                 }
-                .into(),
-            );
-        } else if args.is_some() {
-            self.errors.push(
+            } else {
+                PredicateError::InvalidPredicate {
+                    pred: name,
+                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
+                }
+            };
+            self.errors.push(error.into());
+            return;
+        };
+
+        let args = args
+            .as_ref()
+            .map(|args| {
+                let (first, following, _) = args.get_matched();
+                std::iter::once(first)
+                    .chain(following.iter_matched().map(|arg| arg.get_matched().1))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if args.len() != spec.args.len() {
+            let error = if spec.args.is_empty() {
                 PredicateError::ItemGuardPredicateTakesNoArgs {
+                    pred: name,
+                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
+                }
+            } else {
+                PredicateError::InvalidItemGuardArity {
+                    pred: name,
+                    expected: spec.args.len(),
+                    actual: args.len(),
+                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
+                }
+            };
+            self.errors.push(error.into());
+            return;
+        }
+
+        let produces_output = spec.args.iter().any(|arg| arg.mode == ItemPredicateArgMode::Output);
+        let mut valid = true;
+        if is_negated && produces_output {
+            self.errors.push(
+                PredicateError::NegatedItemGuardOutput {
                     pred: name,
                     span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
                 }
                 .into(),
             );
+            valid = false;
+        }
+        if in_disjunction && produces_output {
+            self.errors.push(
+                PredicateError::ItemGuardOutputInDisjunction {
+                    pred: name,
+                    span: SpanWrapper::new(predicate.span, mctx.get_active_path()),
+                }
+                .into(),
+            );
+            valid = false;
+        }
+
+        let mut outputs = Vec::new();
+        for (arg, expected) in args.into_iter().zip(spec.args) {
+            let Choice4::_1(meta_var) = arg.deref() else {
+                self.errors.push(
+                    PredicateError::InvalidItemGuardArgument {
+                        pred: name,
+                        arg: arg.span.as_str(),
+                        expected: expected.kind.name(),
+                        span: SpanWrapper::new(arg.span, mctx.get_active_path()),
+                    }
+                    .into(),
+                );
+                valid = false;
+                continue;
+            };
+            let arg_name = meta_var.span.as_str();
+            if self.symbol_table.item_predicate_arg_kind(arg_name) != Some(expected.kind) {
+                self.errors.push(
+                    PredicateError::InvalidItemGuardArgument {
+                        pred: name,
+                        arg: arg_name,
+                        expected: expected.kind.name(),
+                        span: SpanWrapper::new(meta_var.span, mctx.get_active_path()),
+                    }
+                    .into(),
+                );
+                valid = false;
+                continue;
+            }
+            match expected.mode {
+                ItemPredicateArgMode::Input if !bound.contains(arg_name) => {
+                    self.errors.push(
+                        PredicateError::UnboundItemGuardInput {
+                            pred: name,
+                            arg: arg_name,
+                            span: SpanWrapper::new(meta_var.span, mctx.get_active_path()),
+                        }
+                        .into(),
+                    );
+                    valid = false;
+                },
+                ItemPredicateArgMode::Output => outputs.push(arg_name),
+                ItemPredicateArgMode::Input => {},
+            }
+        }
+
+        if valid && !is_negated && !in_disjunction {
+            bound.extend(outputs);
         }
     }
 

--- a/crates/rpl_meta/src/check/impls.rs
+++ b/crates/rpl_meta/src/check/impls.rs
@@ -19,7 +19,7 @@ pub(super) struct CheckImplCtxt<'i, 'r> {
 
 impl<'i> CheckImplCtxt<'i, '_> {
     pub(super) fn check_impl(&mut self, mctx: &MetaContext<'i>, rust_impl: &'i pairs::Impl<'i>) {
-        let (_, _, _, _, _, fns, _) = rust_impl.get_matched();
+        let (_, _, _, _, _, _, _, _, fns, _) = rust_impl.get_matched();
         for rust_fn in fns.iter_matched() {
             // FIXME: check constraints
             let (rust_fn, _where_block) = rust_fn.get_matched();

--- a/crates/rpl_meta/src/error.rs
+++ b/crates/rpl_meta/src/error.rs
@@ -136,6 +136,20 @@ error_type!(
                 span: SpanWrapper<'i>,
             }
                 "Invalid field index `{index}` ({source}). \n{span}",
+            323 UnqualifiedImplTraitPath {
+                value: &'i str,
+                span: SpanWrapper<'i>,
+            }
+                "Impl trait path `{value}` is unqualified; import it or use a qualified path. \n{span}",
+            324 CyclicImplTraitPathImport {
+                value: &'i str,
+                span: SpanWrapper<'i>,
+            }
+                "Cyclic imports while resolving impl trait path `{value}`. \n{span}",
+            325 UnsupportedImplTraitGenericArguments {
+                span: SpanWrapper<'i>,
+            }
+                "Generic arguments in impl trait paths are not supported yet. \n{span}",
             /* 4xx for diagnostic errors */
             400 MissingPropertyInDiag {
                 property: &'static str,

--- a/crates/rpl_meta/src/symbol_table.rs
+++ b/crates/rpl_meta/src/symbol_table.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use derive_more::derive::{AsRef, Debug, From};
 pub use diag::DiagSymbolTable;
 use either::Either;
-use parser::generics::{Choice3, Choice4};
+use parser::generics::{Choice3, Choice4, Choice5};
 use parser::{SpanWrapper, pairs};
 use pest_typed::{Span, Spanned};
 use rpl_constraints::predicates::{ItemPredicateArgKind, PredicateConjunction};
@@ -50,6 +50,7 @@ pub enum MetaVariableType {
     Type,
     Const,
     Place,
+    Access,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -69,6 +70,7 @@ pub type Type<'i> = &'i pairs::Type<'i>;
 pub struct NonLocalMetaSymTab<'i> {
     type_vars: FlatMap<&'i str, (usize, PredicateConjunction)>,
     adt_vars: FlatMap<&'i str, PredicateConjunction>,
+    access_vars: FlatMap<&'i str, PredicateConjunction>,
     const_vars: FlatMap<&'i str, (usize, Type<'i>, PredicateConjunction)>,
     place_vars: FlatMap<&'i str, (usize, Type<'i>, PredicateConjunction)>,
 }
@@ -79,6 +81,9 @@ impl<'i> NonLocalMetaSymTab<'i> {
     }
     pub fn adt_vars(&self) -> impl Iterator<Item = &'i str> + '_ {
         self.adt_vars.keys().copied()
+    }
+    pub fn access_vars(&self) -> impl Iterator<Item = &'i str> + '_ {
+        self.access_vars.keys().copied()
     }
     pub fn const_vars(&self) -> impl Iterator<Item = (&'i str, usize)> {
         self.const_vars.iter().map(|(symbol, (idx, _, _))| (*symbol, *idx))
@@ -101,7 +106,7 @@ impl<'i> NonLocalMetaSymTab<'i> {
         errors: &mut Vec<RPLMetaError<'i>>,
     ) {
         match meta_var_ty.deref() {
-            Choice4::_0(_) => {
+            Choice5::_0(_) => {
                 let existed = self
                     .type_vars
                     .insert(meta_var.span.as_str(), (self.type_vars.len(), preds));
@@ -113,7 +118,7 @@ impl<'i> NonLocalMetaSymTab<'i> {
                     errors.push(err);
                 }
             },
-            Choice4::_1(_) => {
+            Choice5::_1(_) => {
                 let existed = self.adt_vars.insert(meta_var.span.as_str(), preds);
                 if existed.is_some() {
                     let err = RPLMetaError::NonLocalMetaVariableAlreadyDeclared {
@@ -123,7 +128,17 @@ impl<'i> NonLocalMetaSymTab<'i> {
                     errors.push(err);
                 }
             },
-            Choice4::_2(kind) => {
+            Choice5::_2(_) => {
+                let existed = self.access_vars.insert(meta_var.span.as_str(), preds);
+                if existed.is_some() {
+                    let err = RPLMetaError::NonLocalMetaVariableAlreadyDeclared {
+                        meta_var: meta_var.span.as_str(),
+                        span: SpanWrapper::new(meta_var.span, mctx.get_active_path()),
+                    };
+                    errors.push(err);
+                }
+            },
+            Choice5::_3(kind) => {
                 let (_, _, ty, _) = kind.get_matched();
                 let existed = self
                     .const_vars
@@ -136,7 +151,7 @@ impl<'i> NonLocalMetaSymTab<'i> {
                     errors.push(err);
                 }
             },
-            Choice4::_3(kind) => {
+            Choice5::_4(kind) => {
                 let (_, _, ty, _) = kind.get_matched();
                 let existed = self
                     .place_vars
@@ -187,6 +202,14 @@ impl<'i> NonLocalMetaSymTab<'i> {
             Some(MetaVariable::Type(*idx, preds.clone()))
         } else if let Some(stored_name) = self.adt_vars.keys().copied().find(|stored_name| *stored_name == name) {
             Some(MetaVariable::AdtPat(AdtPatType::Any, stored_name))
+        } else if let Some(stored_name) = self
+            .access_vars
+            .keys()
+            .copied()
+            .find(|stored_name| *stored_name == name)
+        {
+            let preds = self.access_vars.get(&stored_name).expect("stored access metavariable");
+            Some(MetaVariable::Access(stored_name, preds.clone()))
         } else if let Some((idx, ty, preds)) = self.const_vars.get(&name) {
             Some(MetaVariable::Const(*idx, ty, preds.clone()))
         } else if let Some((idx, ty, preds)) = self.place_vars.get(&name) {
@@ -329,6 +352,7 @@ impl<'i> SymbolTable<'i> {
         match self.meta_vars.get_meta_var_from_name(name) {
             Some(MetaVariable::Type(..)) => Some(ItemPredicateArgKind::Type),
             Some(MetaVariable::AdtPat(..)) => Some(ItemPredicateArgKind::Adt),
+            Some(MetaVariable::Access(..)) => Some(ItemPredicateArgKind::Access),
             Some(MetaVariable::Const(..) | MetaVariable::Place(..)) => None,
             None => self.item_binding(name).map(|kind| match kind {
                 ItemBindingType::Impl => ItemPredicateArgKind::Impl,
@@ -1015,6 +1039,7 @@ pub enum MetaVariable<'i> {
     Const(usize, &'i pairs::Type<'i>, PredicateConjunction),
     Place(usize, &'i pairs::Type<'i>, PredicateConjunction),
     AdtPat(AdtPatType, &'i str),
+    Access(&'i str, PredicateConjunction),
 }
 
 impl<'i> MetaVariable<'i> {
@@ -1024,6 +1049,7 @@ impl<'i> MetaVariable<'i> {
             MetaVariable::Const(_, _, _) => Either::Left(MetaVariableType::Const),
             MetaVariable::Place(_, _, _) => Either::Left(MetaVariableType::Place),
             MetaVariable::AdtPat(kind, _) => Either::Right(*kind),
+            MetaVariable::Access(..) => Either::Left(MetaVariableType::Access),
         }
     }
     pub fn expect_const(self) -> (usize, &'i pairs::Type<'i>, PredicateConjunction) {
@@ -1032,6 +1058,7 @@ impl<'i> MetaVariable<'i> {
             MetaVariable::Const(idx, ty, pred) => (idx, ty, pred),
             MetaVariable::Place(_, _, _) => panic!("Expected place meta variable, found ADT"),
             MetaVariable::AdtPat(_, _) => panic!("Expected const meta variable, found ADT"),
+            MetaVariable::Access(..) => panic!("Expected const meta variable, found access"),
         }
     }
     pub fn expect_non_adt(self) -> (MetaVariableType, usize, PredicateConjunction) {
@@ -1040,6 +1067,7 @@ impl<'i> MetaVariable<'i> {
             MetaVariable::Const(idx, _, pred) => (MetaVariableType::Const, idx, pred),
             MetaVariable::Place(idx, _, pred) => (MetaVariableType::Place, idx, pred),
             MetaVariable::AdtPat(_, _) => panic!("Expected non-ADT meta variable, found ADT"),
+            MetaVariable::Access(..) => panic!("Expected indexed meta variable, found access"),
         }
     }
 }

--- a/crates/rpl_meta/src/symbol_table.rs
+++ b/crates/rpl_meta/src/symbol_table.rs
@@ -52,8 +52,9 @@ pub enum MetaVariableType {
     Place,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AdtPatType {
+    Any,
     Struct,
     Enum,
 }
@@ -67,6 +68,7 @@ pub type Type<'i> = &'i pairs::Type<'i>;
 #[derive(Default, Debug)]
 pub struct NonLocalMetaSymTab<'i> {
     type_vars: FlatMap<&'i str, (usize, PredicateConjunction)>,
+    adt_vars: FlatMap<&'i str, PredicateConjunction>,
     const_vars: FlatMap<&'i str, (usize, Type<'i>, PredicateConjunction)>,
     place_vars: FlatMap<&'i str, (usize, Type<'i>, PredicateConjunction)>,
 }
@@ -74,6 +76,9 @@ pub struct NonLocalMetaSymTab<'i> {
 impl<'i> NonLocalMetaSymTab<'i> {
     pub fn type_vars(&self) -> impl Iterator<Item = (&'i str, usize)> {
         self.type_vars.iter().map(|(symbol, (idx, _))| (*symbol, *idx))
+    }
+    pub fn adt_vars(&self) -> impl Iterator<Item = &'i str> + '_ {
+        self.adt_vars.keys().copied()
     }
     pub fn const_vars(&self) -> impl Iterator<Item = (&'i str, usize)> {
         self.const_vars.iter().map(|(symbol, (idx, _, _))| (*symbol, *idx))
@@ -96,7 +101,7 @@ impl<'i> NonLocalMetaSymTab<'i> {
         errors: &mut Vec<RPLMetaError<'i>>,
     ) {
         match meta_var_ty.deref() {
-            Choice3::_0(_) => {
+            Choice4::_0(_) => {
                 let existed = self
                     .type_vars
                     .insert(meta_var.span.as_str(), (self.type_vars.len(), preds));
@@ -108,7 +113,17 @@ impl<'i> NonLocalMetaSymTab<'i> {
                     errors.push(err);
                 }
             },
-            Choice3::_1(kind) => {
+            Choice4::_1(_) => {
+                let existed = self.adt_vars.insert(meta_var.span.as_str(), preds);
+                if existed.is_some() {
+                    let err = RPLMetaError::NonLocalMetaVariableAlreadyDeclared {
+                        meta_var: meta_var.span.as_str(),
+                        span: SpanWrapper::new(meta_var.span, mctx.get_active_path()),
+                    };
+                    errors.push(err);
+                }
+            },
+            Choice4::_2(kind) => {
                 let (_, _, ty, _) = kind.get_matched();
                 let existed = self
                     .const_vars
@@ -121,7 +136,7 @@ impl<'i> NonLocalMetaSymTab<'i> {
                     errors.push(err);
                 }
             },
-            Choice3::_2(kind) => {
+            Choice4::_3(kind) => {
                 let (_, _, ty, _) = kind.get_matched();
                 let existed = self
                     .place_vars
@@ -170,6 +185,8 @@ impl<'i> NonLocalMetaSymTab<'i> {
     pub fn get_meta_var_from_name(&self, name: &str) -> Option<MetaVariable<'i>> {
         if let Some((idx, preds)) = self.type_vars.get(&name) {
             Some(MetaVariable::Type(*idx, preds.clone()))
+        } else if let Some(stored_name) = self.adt_vars.keys().copied().find(|stored_name| *stored_name == name) {
+            Some(MetaVariable::AdtPat(AdtPatType::Any, stored_name))
         } else if let Some((idx, ty, preds)) = self.const_vars.get(&name) {
             Some(MetaVariable::Const(*idx, ty, preds.clone()))
         } else if let Some((idx, ty, preds)) = self.place_vars.get(&name) {
@@ -258,6 +275,11 @@ macro_rules! map_inner {
 pub type Imports<'i> = FxHashMap<&'i str, &'i pairs::Path<'i>>;
 pub type AdtPats<'i> = FlatMap<&'i str, AdtPatType>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ItemBindingType {
+    Impl,
+}
+
 #[derive(Default, AsRef)]
 pub struct SymbolTable<'i> {
     // meta variables in p[$T: ty]
@@ -272,10 +294,33 @@ pub struct SymbolTable<'i> {
     enums: FxHashMap<&'i str, Enum<'i>>,
     fns: FxHashMap<&'i str, Fn<'i>>,
     unnamed_fns: Vec<Fn<'i>>,
-    impls: FxHashMap<(&'i pairs::Type<'i>, Option<&'i pairs::ImplKind<'i>>), Impl<'i>>,
+    impls: FxHashMap<(&'i pairs::ImplSelfType<'i>, Option<&'i pairs::ImplKind<'i>>), Impl<'i>>,
+    item_bindings: FxHashMap<&'i str, ItemBindingType>,
 }
 
 impl<'i> SymbolTable<'i> {
+    pub fn add_item_binding(
+        &mut self,
+        mctx: &MetaContext<'i>,
+        binding: &'i pairs::MetaVariable<'i>,
+        binding_ty: ItemBindingType,
+        errors: &mut Vec<RPLMetaError<'i>>,
+    ) {
+        let name = binding.span.as_str();
+        if self.meta_vars.get_meta_var_from_name(name).is_some()
+            || self.item_bindings.try_insert(name, binding_ty).is_err()
+        {
+            errors.push(RPLMetaError::SymbolAlreadyDeclared {
+                ident: name,
+                span: SpanWrapper::new(binding.span, mctx.get_active_path()),
+            });
+        }
+    }
+
+    pub fn item_binding(&self, name: &str) -> Option<ItemBindingType> {
+        self.item_bindings.get(name).copied()
+    }
+
     pub fn add_enum(
         &mut self,
         mctx: &MetaContext<'i>,
@@ -362,7 +407,7 @@ impl<'i> SymbolTable<'i> {
     ) -> Option<(&mut Impl<'i>, &Imports<'i>, &AdtPats<'i>)> {
         self.impls
             .try_insert(
-                (impl_pat.Type(), impl_pat.ImplKind()),
+                (impl_pat.ImplSelfType(), impl_pat.ImplKind()),
                 (ImplInner::new(impl_pat), self.meta_vars.clone(), &self.adt_pats).into(),
             )
             .map_err(|_| {
@@ -472,7 +517,11 @@ impl<'i> SymbolTable<'i> {
         self.fns.get(&name)
     }
     /// See [`SymbolTable::add_impl`].
-    pub fn get_impl(&self, ty: &'i pairs::Type<'i>, impl_kind: Option<&'i pairs::ImplKind<'i>>) -> Option<&Impl<'i>> {
+    pub fn get_impl(
+        &self,
+        ty: &'i pairs::ImplSelfType<'i>,
+        impl_kind: Option<&'i pairs::ImplKind<'i>>,
+    ) -> Option<&Impl<'i>> {
         // FIXME: how to identify an impl?
         self.impls.get(&(ty, impl_kind))
     }
@@ -897,17 +946,17 @@ pub struct ImplInner<'i> {
     #[allow(dead_code)]
     trait_: Option<&'i pairs::Path<'i>>,
     #[allow(dead_code)]
-    ty: &'i pairs::Type<'i>,
+    ty: &'i pairs::ImplSelfType<'i>,
     fns: FxHashMap<&'i str, Fn<'i>>,
 }
 
 impl<'i> ImplInner<'i> {
     pub fn new(impl_pat: &'i pairs::Impl<'i>) -> Self {
         let impl_pat = impl_pat.get_matched();
-        let trait_ = impl_pat.2.as_ref().map(|trait_| trait_.get_matched().0);
+        let trait_ = impl_pat.4.as_ref().map(|trait_| trait_.get_matched().0);
         Self {
             trait_,
-            ty: impl_pat.3,
+            ty: impl_pat.5,
             fns: FxHashMap::default(),
         }
     }

--- a/crates/rpl_meta/src/symbol_table.rs
+++ b/crates/rpl_meta/src/symbol_table.rs
@@ -7,7 +7,7 @@ use either::Either;
 use parser::generics::{Choice3, Choice4};
 use parser::{SpanWrapper, pairs};
 use pest_typed::{Span, Spanned};
-use rpl_constraints::predicates::PredicateConjunction;
+use rpl_constraints::predicates::{ItemPredicateArgKind, PredicateConjunction};
 use rustc_hash::FxHashMap;
 use rustc_middle::mir;
 
@@ -319,6 +319,21 @@ impl<'i> SymbolTable<'i> {
 
     pub fn item_binding(&self, name: &str) -> Option<ItemBindingType> {
         self.item_bindings.get(name).copied()
+    }
+
+    pub fn item_bindings(&self) -> impl Iterator<Item = (&'i str, ItemBindingType)> + '_ {
+        self.item_bindings.iter().map(|(name, kind)| (*name, *kind))
+    }
+
+    pub fn item_predicate_arg_kind(&self, name: &str) -> Option<ItemPredicateArgKind> {
+        match self.meta_vars.get_meta_var_from_name(name) {
+            Some(MetaVariable::Type(..)) => Some(ItemPredicateArgKind::Type),
+            Some(MetaVariable::AdtPat(..)) => Some(ItemPredicateArgKind::Adt),
+            Some(MetaVariable::Const(..) | MetaVariable::Place(..)) => None,
+            None => self.item_binding(name).map(|kind| match kind {
+                ItemBindingType::Impl => ItemPredicateArgKind::Impl,
+            }),
+        }
     }
 
     pub fn add_enum(

--- a/crates/rpl_meta/tests/function_predicates.rs
+++ b/crates/rpl_meta/tests/function_predicates.rs
@@ -1,0 +1,26 @@
+#![feature(rustc_private)]
+
+use std::path::PathBuf;
+
+use rpl_meta::arena::Arena;
+
+#[test]
+fn accepts_upstream_attribute_predicate_in_function_where_clause() {
+    let arena = &*Box::leak(Box::new(Arena::default()));
+    let sources = &*Box::leak(Box::new(vec![(
+        PathBuf::from("/synthetic/function-predicates.rpl"),
+        r#"
+pattern function-predicates
+
+patt {
+    p = fn $f(..) -> _ {} where {
+        has_attr($f, inline)
+    }
+}
+"#
+        .to_owned(),
+    )]));
+    let mut errors = Vec::new();
+    rpl_meta::parse_and_collect(arena, sources, |error| errors.push(error.to_string()));
+    assert!(errors.is_empty(), "unexpected predicate errors: {errors:#?}");
+}

--- a/crates/rpl_parser/src/grammar/RPL.pest
+++ b/crates/rpl_parser/src/grammar/RPL.pest
@@ -294,9 +294,13 @@ Identifier   = @{ !(Keywords) ~ Word }
 LabelName    = @{ Word }
 MetaVariable = ${ Dollar ~ Word }
 
+// Item-analysis witness type. Keep it soft so `access` remains available as a Rust identifier.
+kw_access = @{ "access" ~ !WordFollowing }
+
 MetaVariableType = {
     kw_type
   | kw_adt
+  | kw_access
   | kw_const ~ LeftParen ~ Type ~ RightParen
   | kw_place ~ LeftParen ~ Type ~ RightParen
 }

--- a/crates/rpl_parser/src/grammar/RPL.pest
+++ b/crates/rpl_parser/src/grammar/RPL.pest
@@ -22,6 +22,7 @@ kw_as              = @{ "as" ~ !WordFollowing }
 kw_crate           = @{ "crate" ~ !WordFollowing }
 kw_use             = @{ "use" ~ !WordFollowing }
 kw_type            = @{ "type" ~ !WordFollowing }
+kw_adt             = @{ "adt" ~ !WordFollowing }
 kw_let             = @{ "let" ~ !WordFollowing }
 kw_move            = @{ "move" ~ !WordFollowing }
 kw_Len             = @{ "Len" ~ !WordFollowing }
@@ -295,6 +296,7 @@ MetaVariable = ${ Dollar ~ Word }
 
 MetaVariableType = {
     kw_type
+  | kw_adt
   | kw_const ~ LeftParen ~ Type ~ RightParen
   | kw_place ~ LeftParen ~ Type ~ RightParen
 }
@@ -882,8 +884,21 @@ FieldsSeparatedByComma = {
     Field ~ (Comma ~ Field)* ~ Comma?
 }
 
+NonExhaustiveFields = {
+    (Field ~ Comma)* ~ Dot2 ~ Comma?
+}
+
+StructFields = {
+    NonExhaustiveFields
+  | FieldsSeparatedByComma
+}
+
+ItemGenericWildcard = {
+    LessThan ~ Dot2 ~ GreaterThan
+}
+
 Struct = {
-    kw_pub? ~ kw_struct ~ MetaVariable ~ LeftBrace ~ FieldsSeparatedByComma? ~ RightBrace
+    kw_pub? ~ kw_struct ~ MetaVariable ~ ItemGenericWildcard? ~ LeftBrace ~ StructFields? ~ RightBrace
 }
 
 EnumVariant = {
@@ -904,8 +919,25 @@ ImplKind = {
     Path ~ kw_for
 }
 
+ItemBinding = {
+    MetaVariable ~ Colon
+}
+
+ItemAdtType = {
+    MetaVariable ~ ItemGenericWildcard
+}
+
+ImplSelfType = {
+    ItemAdtType
+  | Type
+}
+
+ImplWhereClause = {
+    kw_where ~ Dot2
+}
+
 Impl = {
-    kw_unsafe? ~ kw_impl ~ ImplKind? ~ Type ~ LeftBrace ~ (Fn ~ WhereBlock?)* ~ RightBrace
+    ItemBinding? ~ kw_unsafe? ~ kw_impl ~ ItemGenericWildcard? ~ ImplKind? ~ ImplSelfType ~ ImplWhereClause? ~ LeftBrace ~ (Fn ~ WhereBlock?)* ~ RightBrace
 }
 
 RustItem                = {
@@ -917,7 +949,9 @@ RustItem                = {
 RustItemWithConstraint  = {
     Attr* ~ RustItem ~ WhereBlock?
 }
-RustItemsWithConstraint = { LeftBrace ~ (RustItemWithConstraint)+ ~ RightBrace }
+RustItemsWithConstraint = {
+    LeftBrace ~ (RustItemWithConstraint)+ ~ RightBrace ~ WhereBlock?
+}
 
 PatternConfiguration = {
     Identifier ~ MetaVariableAssignList?

--- a/crates/rpl_parser/src/parser.rs
+++ b/crates/rpl_parser/src/parser.rs
@@ -24,6 +24,7 @@ pub enum Rule {
     r#kw_crate,
     r#kw_use,
     r#kw_type,
+    r#kw_adt,
     r#kw_let,
     r#kw_move,
     r#kw_Len,
@@ -277,11 +278,18 @@ pub enum Rule {
     r#Fn,
     r#Field,
     r#FieldsSeparatedByComma,
+    r#NonExhaustiveFields,
+    r#StructFields,
+    r#ItemGenericWildcard,
     r#Struct,
     r#EnumVariant,
     r#EnumVariantsSeparatedByComma,
     r#Enum,
     r#ImplKind,
+    r#ItemBinding,
+    r#ItemAdtType,
+    r#ImplSelfType,
+    r#ImplWhereClause,
     r#Impl,
     r#RustItem,
     r#RustItemWithConstraint,
@@ -440,551 +448,551 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_17 {
         const CONTENT: &'static ::core::primitive::str = "type";
     }
-    #[doc = "A wrapper for `\"let\"`."]
+    #[doc = "A wrapper for `\"adt\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_18;
     impl ::pest_typed::StringWrapper for r#w_18 {
+        const CONTENT: &'static ::core::primitive::str = "adt";
+    }
+    #[doc = "A wrapper for `\"let\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_19;
+    impl ::pest_typed::StringWrapper for r#w_19 {
         const CONTENT: &'static ::core::primitive::str = "let";
     }
     #[doc = "A wrapper for `\"move\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_19;
-    impl ::pest_typed::StringWrapper for r#w_19 {
+    pub struct r#w_20;
+    impl ::pest_typed::StringWrapper for r#w_20 {
         const CONTENT: &'static ::core::primitive::str = "move";
     }
     #[doc = "A wrapper for `\"Len\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_20;
-    impl ::pest_typed::StringWrapper for r#w_20 {
+    pub struct r#w_21;
+    impl ::pest_typed::StringWrapper for r#w_21 {
         const CONTENT: &'static ::core::primitive::str = "Len";
     }
     #[doc = "A wrapper for `\"PtrToPtr\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_21;
-    impl ::pest_typed::StringWrapper for r#w_21 {
+    pub struct r#w_22;
+    impl ::pest_typed::StringWrapper for r#w_22 {
         const CONTENT: &'static ::core::primitive::str = "PtrToPtr";
     }
     #[doc = "A wrapper for `\"IntToInt\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_22;
-    impl ::pest_typed::StringWrapper for r#w_22 {
+    pub struct r#w_23;
+    impl ::pest_typed::StringWrapper for r#w_23 {
         const CONTENT: &'static ::core::primitive::str = "IntToInt";
     }
     #[doc = "A wrapper for `\"Transmute\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_23;
-    impl ::pest_typed::StringWrapper for r#w_23 {
+    pub struct r#w_24;
+    impl ::pest_typed::StringWrapper for r#w_24 {
         const CONTENT: &'static ::core::primitive::str = "Transmute";
     }
     #[doc = "A wrapper for `\"PointerCoercion\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_24;
-    impl ::pest_typed::StringWrapper for r#w_24 {
+    pub struct r#w_25;
+    impl ::pest_typed::StringWrapper for r#w_25 {
         const CONTENT: &'static ::core::primitive::str = "PointerCoercion";
     }
     #[doc = "A wrapper for `\"copy\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_25;
-    impl ::pest_typed::StringWrapper for r#w_25 {
+    pub struct r#w_26;
+    impl ::pest_typed::StringWrapper for r#w_26 {
         const CONTENT: &'static ::core::primitive::str = "copy";
     }
     #[doc = "A wrapper for `\"Unsize\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_26;
-    impl ::pest_typed::StringWrapper for r#w_26 {
+    pub struct r#w_27;
+    impl ::pest_typed::StringWrapper for r#w_27 {
         const CONTENT: &'static ::core::primitive::str = "Unsize";
     }
     #[doc = "A wrapper for `\"Implicit\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_27;
-    impl ::pest_typed::StringWrapper for r#w_27 {
+    pub struct r#w_28;
+    impl ::pest_typed::StringWrapper for r#w_28 {
         const CONTENT: &'static ::core::primitive::str = "Implicit";
     }
     #[doc = "A wrapper for `\"PointerExposeProvenance\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_28;
-    impl ::pest_typed::StringWrapper for r#w_28 {
+    pub struct r#w_29;
+    impl ::pest_typed::StringWrapper for r#w_29 {
         const CONTENT: &'static ::core::primitive::str = "PointerExposeProvenance";
     }
     #[doc = "A wrapper for `\"PointerWithExposedProvenance\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_29;
-    impl ::pest_typed::StringWrapper for r#w_29 {
+    pub struct r#w_30;
+    impl ::pest_typed::StringWrapper for r#w_30 {
         const CONTENT: &'static ::core::primitive::str = "PointerWithExposedProvenance";
     }
     #[doc = "A wrapper for `\"restricted\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_30;
-    impl ::pest_typed::StringWrapper for r#w_30 {
+    pub struct r#w_31;
+    impl ::pest_typed::StringWrapper for r#w_31 {
         const CONTENT: &'static ::core::primitive::str = "restricted";
     }
     #[doc = "A wrapper for `\"Add\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_31;
-    impl ::pest_typed::StringWrapper for r#w_31 {
+    pub struct r#w_32;
+    impl ::pest_typed::StringWrapper for r#w_32 {
         const CONTENT: &'static ::core::primitive::str = "Add";
     }
     #[doc = "A wrapper for `\"Sub\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_32;
-    impl ::pest_typed::StringWrapper for r#w_32 {
+    pub struct r#w_33;
+    impl ::pest_typed::StringWrapper for r#w_33 {
         const CONTENT: &'static ::core::primitive::str = "Sub";
     }
     #[doc = "A wrapper for `\"Mul\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_33;
-    impl ::pest_typed::StringWrapper for r#w_33 {
+    pub struct r#w_34;
+    impl ::pest_typed::StringWrapper for r#w_34 {
         const CONTENT: &'static ::core::primitive::str = "Mul";
     }
     #[doc = "A wrapper for `\"Div\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_34;
-    impl ::pest_typed::StringWrapper for r#w_34 {
+    pub struct r#w_35;
+    impl ::pest_typed::StringWrapper for r#w_35 {
         const CONTENT: &'static ::core::primitive::str = "Div";
     }
     #[doc = "A wrapper for `\"Rem\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_35;
-    impl ::pest_typed::StringWrapper for r#w_35 {
+    pub struct r#w_36;
+    impl ::pest_typed::StringWrapper for r#w_36 {
         const CONTENT: &'static ::core::primitive::str = "Rem";
     }
     #[doc = "A wrapper for `\"Lt\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_36;
-    impl ::pest_typed::StringWrapper for r#w_36 {
+    pub struct r#w_37;
+    impl ::pest_typed::StringWrapper for r#w_37 {
         const CONTENT: &'static ::core::primitive::str = "Lt";
     }
     #[doc = "A wrapper for `\"Le\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_37;
-    impl ::pest_typed::StringWrapper for r#w_37 {
+    pub struct r#w_38;
+    impl ::pest_typed::StringWrapper for r#w_38 {
         const CONTENT: &'static ::core::primitive::str = "Le";
     }
     #[doc = "A wrapper for `\"Gt\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_38;
-    impl ::pest_typed::StringWrapper for r#w_38 {
+    pub struct r#w_39;
+    impl ::pest_typed::StringWrapper for r#w_39 {
         const CONTENT: &'static ::core::primitive::str = "Gt";
     }
     #[doc = "A wrapper for `\"Ge\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_39;
-    impl ::pest_typed::StringWrapper for r#w_39 {
+    pub struct r#w_40;
+    impl ::pest_typed::StringWrapper for r#w_40 {
         const CONTENT: &'static ::core::primitive::str = "Ge";
     }
     #[doc = "A wrapper for `\"Eq\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_40;
-    impl ::pest_typed::StringWrapper for r#w_40 {
+    pub struct r#w_41;
+    impl ::pest_typed::StringWrapper for r#w_41 {
         const CONTENT: &'static ::core::primitive::str = "Eq";
     }
     #[doc = "A wrapper for `\"Ne\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_41;
-    impl ::pest_typed::StringWrapper for r#w_41 {
+    pub struct r#w_42;
+    impl ::pest_typed::StringWrapper for r#w_42 {
         const CONTENT: &'static ::core::primitive::str = "Ne";
     }
     #[doc = "A wrapper for `\"BitAnd\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_42;
-    impl ::pest_typed::StringWrapper for r#w_42 {
+    pub struct r#w_43;
+    impl ::pest_typed::StringWrapper for r#w_43 {
         const CONTENT: &'static ::core::primitive::str = "BitAnd";
     }
     #[doc = "A wrapper for `\"BitOr\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_43;
-    impl ::pest_typed::StringWrapper for r#w_43 {
+    pub struct r#w_44;
+    impl ::pest_typed::StringWrapper for r#w_44 {
         const CONTENT: &'static ::core::primitive::str = "BitOr";
     }
     #[doc = "A wrapper for `\"BitXor\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_44;
-    impl ::pest_typed::StringWrapper for r#w_44 {
+    pub struct r#w_45;
+    impl ::pest_typed::StringWrapper for r#w_45 {
         const CONTENT: &'static ::core::primitive::str = "BitXor";
     }
     #[doc = "A wrapper for `\"Offset\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_45;
-    impl ::pest_typed::StringWrapper for r#w_45 {
+    pub struct r#w_46;
+    impl ::pest_typed::StringWrapper for r#w_46 {
         const CONTENT: &'static ::core::primitive::str = "Offset";
     }
     #[doc = "A wrapper for `\"SizeOf\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_46;
-    impl ::pest_typed::StringWrapper for r#w_46 {
+    pub struct r#w_47;
+    impl ::pest_typed::StringWrapper for r#w_47 {
         const CONTENT: &'static ::core::primitive::str = "SizeOf";
     }
     #[doc = "A wrapper for `\"AlignOf\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_47;
-    impl ::pest_typed::StringWrapper for r#w_47 {
+    pub struct r#w_48;
+    impl ::pest_typed::StringWrapper for r#w_48 {
         const CONTENT: &'static ::core::primitive::str = "AlignOf";
     }
     #[doc = "A wrapper for `\"Neg\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_48;
-    impl ::pest_typed::StringWrapper for r#w_48 {
+    pub struct r#w_49;
+    impl ::pest_typed::StringWrapper for r#w_49 {
         const CONTENT: &'static ::core::primitive::str = "Neg";
     }
     #[doc = "A wrapper for `\"Not\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_49;
-    impl ::pest_typed::StringWrapper for r#w_49 {
+    pub struct r#w_50;
+    impl ::pest_typed::StringWrapper for r#w_50 {
         const CONTENT: &'static ::core::primitive::str = "Not";
     }
     #[doc = "A wrapper for `\"PtrMetadata\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_50;
-    impl ::pest_typed::StringWrapper for r#w_50 {
+    pub struct r#w_51;
+    impl ::pest_typed::StringWrapper for r#w_51 {
         const CONTENT: &'static ::core::primitive::str = "PtrMetadata";
     }
     #[doc = "A wrapper for `\"discriminant\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_51;
-    impl ::pest_typed::StringWrapper for r#w_51 {
+    pub struct r#w_52;
+    impl ::pest_typed::StringWrapper for r#w_52 {
         const CONTENT: &'static ::core::primitive::str = "discriminant";
     }
     #[doc = "A wrapper for `\"Ctor\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_52;
-    impl ::pest_typed::StringWrapper for r#w_52 {
+    pub struct r#w_53;
+    impl ::pest_typed::StringWrapper for r#w_53 {
         const CONTENT: &'static ::core::primitive::str = "Ctor";
     }
     #[doc = "A wrapper for `\"from\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_53;
-    impl ::pest_typed::StringWrapper for r#w_53 {
+    pub struct r#w_54;
+    impl ::pest_typed::StringWrapper for r#w_54 {
         const CONTENT: &'static ::core::primitive::str = "from";
     }
     #[doc = "A wrapper for `\"of\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_54;
-    impl ::pest_typed::StringWrapper for r#w_54 {
+    pub struct r#w_55;
+    impl ::pest_typed::StringWrapper for r#w_55 {
         const CONTENT: &'static ::core::primitive::str = "of";
     }
     #[doc = "A wrapper for `\"raw\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_55;
-    impl ::pest_typed::StringWrapper for r#w_55 {
+    pub struct r#w_56;
+    impl ::pest_typed::StringWrapper for r#w_56 {
         const CONTENT: &'static ::core::primitive::str = "raw";
     }
     #[doc = "A wrapper for `\"unreachable\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_56;
-    impl ::pest_typed::StringWrapper for r#w_56 {
+    pub struct r#w_57;
+    impl ::pest_typed::StringWrapper for r#w_57 {
         const CONTENT: &'static ::core::primitive::str = "unreachable";
     }
     #[doc = "A wrapper for `\"drop\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_57;
-    impl ::pest_typed::StringWrapper for r#w_57 {
+    pub struct r#w_58;
+    impl ::pest_typed::StringWrapper for r#w_58 {
         const CONTENT: &'static ::core::primitive::str = "drop";
     }
     #[doc = "A wrapper for `\"break\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_58;
-    impl ::pest_typed::StringWrapper for r#w_58 {
+    pub struct r#w_59;
+    impl ::pest_typed::StringWrapper for r#w_59 {
         const CONTENT: &'static ::core::primitive::str = "break";
     }
     #[doc = "A wrapper for `\"continue\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_59;
-    impl ::pest_typed::StringWrapper for r#w_59 {
+    pub struct r#w_60;
+    impl ::pest_typed::StringWrapper for r#w_60 {
         const CONTENT: &'static ::core::primitive::str = "continue";
     }
     #[doc = "A wrapper for `\"loop\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_60;
-    impl ::pest_typed::StringWrapper for r#w_60 {
+    pub struct r#w_61;
+    impl ::pest_typed::StringWrapper for r#w_61 {
         const CONTENT: &'static ::core::primitive::str = "loop";
     }
     #[doc = "A wrapper for `\"return\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_61;
-    impl ::pest_typed::StringWrapper for r#w_61 {
+    pub struct r#w_62;
+    impl ::pest_typed::StringWrapper for r#w_62 {
         const CONTENT: &'static ::core::primitive::str = "return";
     }
     #[doc = "A wrapper for `\"switchInt\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_62;
-    impl ::pest_typed::StringWrapper for r#w_62 {
+    pub struct r#w_63;
+    impl ::pest_typed::StringWrapper for r#w_63 {
         const CONTENT: &'static ::core::primitive::str = "switchInt";
     }
     #[doc = "A wrapper for `\"true\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_63;
-    impl ::pest_typed::StringWrapper for r#w_63 {
+    pub struct r#w_64;
+    impl ::pest_typed::StringWrapper for r#w_64 {
         const CONTENT: &'static ::core::primitive::str = "true";
     }
     #[doc = "A wrapper for `\"false\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_64;
-    impl ::pest_typed::StringWrapper for r#w_64 {
+    pub struct r#w_65;
+    impl ::pest_typed::StringWrapper for r#w_65 {
         const CONTENT: &'static ::core::primitive::str = "false";
     }
     #[doc = "A wrapper for `\"unsafe\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_65;
-    impl ::pest_typed::StringWrapper for r#w_65 {
+    pub struct r#w_66;
+    impl ::pest_typed::StringWrapper for r#w_66 {
         const CONTENT: &'static ::core::primitive::str = "unsafe";
     }
     #[doc = "A wrapper for `\"pub\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_66;
-    impl ::pest_typed::StringWrapper for r#w_66 {
+    pub struct r#w_67;
+    impl ::pest_typed::StringWrapper for r#w_67 {
         const CONTENT: &'static ::core::primitive::str = "pub";
     }
     #[doc = "A wrapper for `\"struct\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_67;
-    impl ::pest_typed::StringWrapper for r#w_67 {
+    pub struct r#w_68;
+    impl ::pest_typed::StringWrapper for r#w_68 {
         const CONTENT: &'static ::core::primitive::str = "struct";
     }
     #[doc = "A wrapper for `\"enum\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_68;
-    impl ::pest_typed::StringWrapper for r#w_68 {
+    pub struct r#w_69;
+    impl ::pest_typed::StringWrapper for r#w_69 {
         const CONTENT: &'static ::core::primitive::str = "enum";
     }
     #[doc = "A wrapper for `\"impl\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_69;
-    impl ::pest_typed::StringWrapper for r#w_69 {
+    pub struct r#w_70;
+    impl ::pest_typed::StringWrapper for r#w_70 {
         const CONTENT: &'static ::core::primitive::str = "impl";
     }
     #[doc = "A wrapper for `\"for\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_70;
-    impl ::pest_typed::StringWrapper for r#w_70 {
+    pub struct r#w_71;
+    impl ::pest_typed::StringWrapper for r#w_71 {
         const CONTENT: &'static ::core::primitive::str = "for";
     }
     #[doc = "A wrapper for `\"place\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_71;
-    impl ::pest_typed::StringWrapper for r#w_71 {
+    pub struct r#w_72;
+    impl ::pest_typed::StringWrapper for r#w_72 {
         const CONTENT: &'static ::core::primitive::str = "place";
     }
     #[doc = "A wrapper for `\"where\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_72;
-    impl ::pest_typed::StringWrapper for r#w_72 {
+    pub struct r#w_73;
+    impl ::pest_typed::StringWrapper for r#w_73 {
         const CONTENT: &'static ::core::primitive::str = "where";
     }
     #[doc = "A wrapper for `\"RET\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_73;
-    impl ::pest_typed::StringWrapper for r#w_73 {
+    pub struct r#w_74;
+    impl ::pest_typed::StringWrapper for r#w_74 {
         const CONTENT: &'static ::core::primitive::str = "RET";
     }
     #[doc = "A wrapper for `\"copy_nonoverlapping\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_74;
-    impl ::pest_typed::StringWrapper for r#w_74 {
+    pub struct r#w_75;
+    impl ::pest_typed::StringWrapper for r#w_75 {
         const CONTENT: &'static ::core::primitive::str = "copy_nonoverlapping";
     }
     #[doc = "A wrapper for `\"u8\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_75;
-    impl ::pest_typed::StringWrapper for r#w_75 {
+    pub struct r#w_76;
+    impl ::pest_typed::StringWrapper for r#w_76 {
         const CONTENT: &'static ::core::primitive::str = "u8";
     }
     #[doc = "A wrapper for `\"u16\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_76;
-    impl ::pest_typed::StringWrapper for r#w_76 {
+    pub struct r#w_77;
+    impl ::pest_typed::StringWrapper for r#w_77 {
         const CONTENT: &'static ::core::primitive::str = "u16";
     }
     #[doc = "A wrapper for `\"u32\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_77;
-    impl ::pest_typed::StringWrapper for r#w_77 {
+    pub struct r#w_78;
+    impl ::pest_typed::StringWrapper for r#w_78 {
         const CONTENT: &'static ::core::primitive::str = "u32";
     }
     #[doc = "A wrapper for `\"u64\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_78;
-    impl ::pest_typed::StringWrapper for r#w_78 {
+    pub struct r#w_79;
+    impl ::pest_typed::StringWrapper for r#w_79 {
         const CONTENT: &'static ::core::primitive::str = "u64";
     }
     #[doc = "A wrapper for `\"usize\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_79;
-    impl ::pest_typed::StringWrapper for r#w_79 {
+    pub struct r#w_80;
+    impl ::pest_typed::StringWrapper for r#w_80 {
         const CONTENT: &'static ::core::primitive::str = "usize";
     }
     #[doc = "A wrapper for `\"i8\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_80;
-    impl ::pest_typed::StringWrapper for r#w_80 {
+    pub struct r#w_81;
+    impl ::pest_typed::StringWrapper for r#w_81 {
         const CONTENT: &'static ::core::primitive::str = "i8";
     }
     #[doc = "A wrapper for `\"i16\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_81;
-    impl ::pest_typed::StringWrapper for r#w_81 {
+    pub struct r#w_82;
+    impl ::pest_typed::StringWrapper for r#w_82 {
         const CONTENT: &'static ::core::primitive::str = "i16";
     }
     #[doc = "A wrapper for `\"i32\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_82;
-    impl ::pest_typed::StringWrapper for r#w_82 {
+    pub struct r#w_83;
+    impl ::pest_typed::StringWrapper for r#w_83 {
         const CONTENT: &'static ::core::primitive::str = "i32";
     }
     #[doc = "A wrapper for `\"i64\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_83;
-    impl ::pest_typed::StringWrapper for r#w_83 {
+    pub struct r#w_84;
+    impl ::pest_typed::StringWrapper for r#w_84 {
         const CONTENT: &'static ::core::primitive::str = "i64";
     }
     #[doc = "A wrapper for `\"isize\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_84;
-    impl ::pest_typed::StringWrapper for r#w_84 {
+    pub struct r#w_85;
+    impl ::pest_typed::StringWrapper for r#w_85 {
         const CONTENT: &'static ::core::primitive::str = "isize";
     }
     #[doc = "A wrapper for `\"bool\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_85;
-    impl ::pest_typed::StringWrapper for r#w_85 {
+    pub struct r#w_86;
+    impl ::pest_typed::StringWrapper for r#w_86 {
         const CONTENT: &'static ::core::primitive::str = "bool";
     }
     #[doc = "A wrapper for `\"str\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_86;
-    impl ::pest_typed::StringWrapper for r#w_86 {
+    pub struct r#w_87;
+    impl ::pest_typed::StringWrapper for r#w_87 {
         const CONTENT: &'static ::core::primitive::str = "str";
     }
     #[doc = "A wrapper for `\"///\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_87;
-    impl ::pest_typed::StringWrapper for r#w_87 {
+    pub struct r#w_88;
+    impl ::pest_typed::StringWrapper for r#w_88 {
         const CONTENT: &'static ::core::primitive::str = "///";
     }
     #[doc = "A wrapper for `\"/\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_88;
-    impl ::pest_typed::StringWrapper for r#w_88 {
+    pub struct r#w_89;
+    impl ::pest_typed::StringWrapper for r#w_89 {
         const CONTENT: &'static ::core::primitive::str = "/";
     }
     #[doc = "A wrapper for `\"//!\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_89;
-    impl ::pest_typed::StringWrapper for r#w_89 {
+    pub struct r#w_90;
+    impl ::pest_typed::StringWrapper for r#w_90 {
         const CONTENT: &'static ::core::primitive::str = "//!";
     }
     #[doc = "A wrapper for `\"//\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_90;
-    impl ::pest_typed::StringWrapper for r#w_90 {
+    pub struct r#w_91;
+    impl ::pest_typed::StringWrapper for r#w_91 {
         const CONTENT: &'static ::core::primitive::str = "//";
     }
     #[doc = "A wrapper for `\"/\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_91;
-    impl ::pest_typed::StringWrapper for r#w_91 {
+    pub struct r#w_92;
+    impl ::pest_typed::StringWrapper for r#w_92 {
         const CONTENT: &'static ::core::primitive::str = "/";
     }
     #[doc = "A wrapper for `\"!\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_92;
-    impl ::pest_typed::StringWrapper for r#w_92 {
+    pub struct r#w_93;
+    impl ::pest_typed::StringWrapper for r#w_93 {
         const CONTENT: &'static ::core::primitive::str = "!";
     }
     #[doc = "A wrapper for `\"////\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_93;
-    impl ::pest_typed::StringWrapper for r#w_93 {
+    pub struct r#w_94;
+    impl ::pest_typed::StringWrapper for r#w_94 {
         const CONTENT: &'static ::core::primitive::str = "////";
     }
     #[doc = "A wrapper for `\"/*\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_94;
-    impl ::pest_typed::StringWrapper for r#w_94 {
-        const CONTENT: &'static ::core::primitive::str = "/*";
-    }
-    #[doc = "A wrapper for `\"*/\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_95;
     impl ::pest_typed::StringWrapper for r#w_95 {
-        const CONTENT: &'static ::core::primitive::str = "*/";
+        const CONTENT: &'static ::core::primitive::str = "/*";
     }
     #[doc = "A wrapper for `\"*/\"`."]
     #[allow(non_camel_case_types)]
@@ -993,236 +1001,236 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_96 {
         const CONTENT: &'static ::core::primitive::str = "*/";
     }
-    #[doc = "A wrapper for `\" \"`."]
+    #[doc = "A wrapper for `\"*/\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_97;
     impl ::pest_typed::StringWrapper for r#w_97 {
+        const CONTENT: &'static ::core::primitive::str = "*/";
+    }
+    #[doc = "A wrapper for `\" \"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_98;
+    impl ::pest_typed::StringWrapper for r#w_98 {
         const CONTENT: &'static ::core::primitive::str = " ";
     }
     #[doc = "A wrapper for `\"\\t\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_98;
-    impl ::pest_typed::StringWrapper for r#w_98 {
+    pub struct r#w_99;
+    impl ::pest_typed::StringWrapper for r#w_99 {
         const CONTENT: &'static ::core::primitive::str = "\t";
     }
     #[doc = "A wrapper for `\"\\r\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_99;
-    impl ::pest_typed::StringWrapper for r#w_99 {
+    pub struct r#w_100;
+    impl ::pest_typed::StringWrapper for r#w_100 {
         const CONTENT: &'static ::core::primitive::str = "\r";
     }
     #[doc = "A wrapper for `\"\\n\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_100;
-    impl ::pest_typed::StringWrapper for r#w_100 {
+    pub struct r#w_101;
+    impl ::pest_typed::StringWrapper for r#w_101 {
         const CONTENT: &'static ::core::primitive::str = "\n";
     }
     #[doc = "A wrapper for `\"{\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_101;
-    impl ::pest_typed::StringWrapper for r#w_101 {
+    pub struct r#w_102;
+    impl ::pest_typed::StringWrapper for r#w_102 {
         const CONTENT: &'static ::core::primitive::str = "{";
     }
     #[doc = "A wrapper for `\"}\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_102;
-    impl ::pest_typed::StringWrapper for r#w_102 {
+    pub struct r#w_103;
+    impl ::pest_typed::StringWrapper for r#w_103 {
         const CONTENT: &'static ::core::primitive::str = "}";
     }
     #[doc = "A wrapper for `\"[\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_103;
-    impl ::pest_typed::StringWrapper for r#w_103 {
+    pub struct r#w_104;
+    impl ::pest_typed::StringWrapper for r#w_104 {
         const CONTENT: &'static ::core::primitive::str = "[";
     }
     #[doc = "A wrapper for `\"]\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_104;
-    impl ::pest_typed::StringWrapper for r#w_104 {
+    pub struct r#w_105;
+    impl ::pest_typed::StringWrapper for r#w_105 {
         const CONTENT: &'static ::core::primitive::str = "]";
     }
     #[doc = "A wrapper for `\"(\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_105;
-    impl ::pest_typed::StringWrapper for r#w_105 {
+    pub struct r#w_106;
+    impl ::pest_typed::StringWrapper for r#w_106 {
         const CONTENT: &'static ::core::primitive::str = "(";
     }
     #[doc = "A wrapper for `\")\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_106;
-    impl ::pest_typed::StringWrapper for r#w_106 {
+    pub struct r#w_107;
+    impl ::pest_typed::StringWrapper for r#w_107 {
         const CONTENT: &'static ::core::primitive::str = ")";
     }
     #[doc = "A wrapper for `\"<\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_107;
-    impl ::pest_typed::StringWrapper for r#w_107 {
+    pub struct r#w_108;
+    impl ::pest_typed::StringWrapper for r#w_108 {
         const CONTENT: &'static ::core::primitive::str = "<";
     }
     #[doc = "A wrapper for `\">\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_108;
-    impl ::pest_typed::StringWrapper for r#w_108 {
+    pub struct r#w_109;
+    impl ::pest_typed::StringWrapper for r#w_109 {
         const CONTENT: &'static ::core::primitive::str = ">";
     }
     #[doc = "A wrapper for `\"$\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_109;
-    impl ::pest_typed::StringWrapper for r#w_109 {
+    pub struct r#w_110;
+    impl ::pest_typed::StringWrapper for r#w_110 {
         const CONTENT: &'static ::core::primitive::str = "$";
     }
     #[doc = "A wrapper for `\"=\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_110;
-    impl ::pest_typed::StringWrapper for r#w_110 {
+    pub struct r#w_111;
+    impl ::pest_typed::StringWrapper for r#w_111 {
         const CONTENT: &'static ::core::primitive::str = "=";
     }
     #[doc = "A wrapper for `\",\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_111;
-    impl ::pest_typed::StringWrapper for r#w_111 {
+    pub struct r#w_112;
+    impl ::pest_typed::StringWrapper for r#w_112 {
         const CONTENT: &'static ::core::primitive::str = ",";
     }
     #[doc = "A wrapper for `\".\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_112;
-    impl ::pest_typed::StringWrapper for r#w_112 {
+    pub struct r#w_113;
+    impl ::pest_typed::StringWrapper for r#w_113 {
         const CONTENT: &'static ::core::primitive::str = ".";
     }
     #[doc = "A wrapper for `\"..\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_113;
-    impl ::pest_typed::StringWrapper for r#w_113 {
+    pub struct r#w_114;
+    impl ::pest_typed::StringWrapper for r#w_114 {
         const CONTENT: &'static ::core::primitive::str = "..";
     }
     #[doc = "A wrapper for `\":\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_114;
-    impl ::pest_typed::StringWrapper for r#w_114 {
+    pub struct r#w_115;
+    impl ::pest_typed::StringWrapper for r#w_115 {
         const CONTENT: &'static ::core::primitive::str = ":";
     }
     #[doc = "A wrapper for `\"::\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_115;
-    impl ::pest_typed::StringWrapper for r#w_115 {
+    pub struct r#w_116;
+    impl ::pest_typed::StringWrapper for r#w_116 {
         const CONTENT: &'static ::core::primitive::str = "::";
     }
     #[doc = "A wrapper for `\";\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_116;
-    impl ::pest_typed::StringWrapper for r#w_116 {
+    pub struct r#w_117;
+    impl ::pest_typed::StringWrapper for r#w_117 {
         const CONTENT: &'static ::core::primitive::str = ";";
     }
     #[doc = "A wrapper for `\"#\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_117;
-    impl ::pest_typed::StringWrapper for r#w_117 {
+    pub struct r#w_118;
+    impl ::pest_typed::StringWrapper for r#w_118 {
         const CONTENT: &'static ::core::primitive::str = "#";
     }
     #[doc = "A wrapper for `\"&\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_118;
-    impl ::pest_typed::StringWrapper for r#w_118 {
+    pub struct r#w_119;
+    impl ::pest_typed::StringWrapper for r#w_119 {
         const CONTENT: &'static ::core::primitive::str = "&";
     }
     #[doc = "A wrapper for `\"&&\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_119;
-    impl ::pest_typed::StringWrapper for r#w_119 {
+    pub struct r#w_120;
+    impl ::pest_typed::StringWrapper for r#w_120 {
         const CONTENT: &'static ::core::primitive::str = "&&";
     }
     #[doc = "A wrapper for `\"||\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_120;
-    impl ::pest_typed::StringWrapper for r#w_120 {
+    pub struct r#w_121;
+    impl ::pest_typed::StringWrapper for r#w_121 {
         const CONTENT: &'static ::core::primitive::str = "||";
     }
     #[doc = "A wrapper for `\"!\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_121;
-    impl ::pest_typed::StringWrapper for r#w_121 {
+    pub struct r#w_122;
+    impl ::pest_typed::StringWrapper for r#w_122 {
         const CONTENT: &'static ::core::primitive::str = "!";
     }
     #[doc = "A wrapper for `\"?\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_122;
-    impl ::pest_typed::StringWrapper for r#w_122 {
+    pub struct r#w_123;
+    impl ::pest_typed::StringWrapper for r#w_123 {
         const CONTENT: &'static ::core::primitive::str = "?";
     }
     #[doc = "A wrapper for `\"*\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_123;
-    impl ::pest_typed::StringWrapper for r#w_123 {
+    pub struct r#w_124;
+    impl ::pest_typed::StringWrapper for r#w_124 {
         const CONTENT: &'static ::core::primitive::str = "*";
     }
     #[doc = "A wrapper for `\"->\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_124;
-    impl ::pest_typed::StringWrapper for r#w_124 {
+    pub struct r#w_125;
+    impl ::pest_typed::StringWrapper for r#w_125 {
         const CONTENT: &'static ::core::primitive::str = "->";
     }
     #[doc = "A wrapper for `\"=>\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_125;
-    impl ::pest_typed::StringWrapper for r#w_125 {
+    pub struct r#w_126;
+    impl ::pest_typed::StringWrapper for r#w_126 {
         const CONTENT: &'static ::core::primitive::str = "=>";
     }
     #[doc = "A wrapper for `\"'\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_126;
-    impl ::pest_typed::StringWrapper for r#w_126 {
+    pub struct r#w_127;
+    impl ::pest_typed::StringWrapper for r#w_127 {
         const CONTENT: &'static ::core::primitive::str = "'";
     }
     #[doc = "A wrapper for `\"+\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_127;
-    impl ::pest_typed::StringWrapper for r#w_127 {
+    pub struct r#w_128;
+    impl ::pest_typed::StringWrapper for r#w_128 {
         const CONTENT: &'static ::core::primitive::str = "+";
     }
     #[doc = "A wrapper for `\"-\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_128;
-    impl ::pest_typed::StringWrapper for r#w_128 {
-        const CONTENT: &'static ::core::primitive::str = "-";
-    }
-    #[doc = "A wrapper for `\"_\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_129;
     impl ::pest_typed::StringWrapper for r#w_129 {
-        const CONTENT: &'static ::core::primitive::str = "_";
+        const CONTENT: &'static ::core::primitive::str = "-";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
@@ -1231,19 +1239,19 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_130 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"0b\"`."]
+    #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_131;
     impl ::pest_typed::StringWrapper for r#w_131 {
-        const CONTENT: &'static ::core::primitive::str = "0b";
+        const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"_\"`."]
+    #[doc = "A wrapper for `\"0b\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_132;
     impl ::pest_typed::StringWrapper for r#w_132 {
-        const CONTENT: &'static ::core::primitive::str = "_";
+        const CONTENT: &'static ::core::primitive::str = "0b";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
@@ -1252,19 +1260,19 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_133 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"0o\"`."]
+    #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_134;
     impl ::pest_typed::StringWrapper for r#w_134 {
-        const CONTENT: &'static ::core::primitive::str = "0o";
+        const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"_\"`."]
+    #[doc = "A wrapper for `\"0o\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_135;
     impl ::pest_typed::StringWrapper for r#w_135 {
-        const CONTENT: &'static ::core::primitive::str = "_";
+        const CONTENT: &'static ::core::primitive::str = "0o";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
@@ -1273,19 +1281,19 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_136 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"0x\"`."]
+    #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_137;
     impl ::pest_typed::StringWrapper for r#w_137 {
-        const CONTENT: &'static ::core::primitive::str = "0x";
+        const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"_\"`."]
+    #[doc = "A wrapper for `\"0x\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_138;
     impl ::pest_typed::StringWrapper for r#w_138 {
-        const CONTENT: &'static ::core::primitive::str = "_";
+        const CONTENT: &'static ::core::primitive::str = "0x";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
@@ -1294,54 +1302,54 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_139 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
-    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_140;
     impl ::pest_typed::StringWrapper for r#w_140 {
+        const CONTENT: &'static ::core::primitive::str = "_";
+    }
+    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_141;
+    impl ::pest_typed::StringWrapper for r#w_141 {
         const CONTENT: &'static ::core::primitive::str = "\"";
     }
     #[doc = "A wrapper for `[\"\\\"\"]`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, PartialEq)]
-    pub struct r#w_141;
-    impl ::pest_typed::StringArrayWrapper for r#w_141 {
+    pub struct r#w_142;
+    impl ::pest_typed::StringArrayWrapper for r#w_142 {
         const CONTENT: &'static [&'static ::core::primitive::str] = &["\""];
     }
     #[doc = "A wrapper for `\"\\\"\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_142;
-    impl ::pest_typed::StringWrapper for r#w_142 {
+    pub struct r#w_143;
+    impl ::pest_typed::StringWrapper for r#w_143 {
         const CONTENT: &'static ::core::primitive::str = "\"";
     }
     #[doc = "A wrapper for `\"_\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_143;
-    impl ::pest_typed::StringWrapper for r#w_143 {
+    pub struct r#w_144;
+    impl ::pest_typed::StringWrapper for r#w_144 {
         const CONTENT: &'static ::core::primitive::str = "_";
     }
     #[doc = "A wrapper for `\"-\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_144;
-    impl ::pest_typed::StringWrapper for r#w_144 {
+    pub struct r#w_145;
+    impl ::pest_typed::StringWrapper for r#w_145 {
         const CONTENT: &'static ::core::primitive::str = "-";
     }
     #[doc = "A wrapper for `\"Group\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
-    pub struct r#w_145;
-    impl ::pest_typed::StringWrapper for r#w_145 {
-        const CONTENT: &'static ::core::primitive::str = "Group";
-    }
-    #[doc = "A wrapper for `\"\\\"\"`."]
-    #[allow(non_camel_case_types)]
-    #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_146;
     impl ::pest_typed::StringWrapper for r#w_146 {
-        const CONTENT: &'static ::core::primitive::str = "\"";
+        const CONTENT: &'static ::core::primitive::str = "Group";
     }
     #[doc = "A wrapper for `\"\\\"\"`."]
     #[allow(non_camel_case_types)]
@@ -1355,6 +1363,13 @@ mod constant_wrappers {
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_148;
     impl ::pest_typed::StringWrapper for r#w_148 {
+        const CONTENT: &'static ::core::primitive::str = "\"";
+    }
+    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_149;
+    impl ::pest_typed::StringWrapper for r#w_149 {
         const CONTENT: &'static ::core::primitive::str = "\"";
     }
 }
@@ -1400,143 +1415,145 @@ pub mod rules_impl {
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_use<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#kw_type , "Corresponds to expression: `(\"type\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_type , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_17 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_type<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_let , "Corresponds to expression: `(\"let\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_let , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_18 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_adt , "Corresponds to expression: `(\"adt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_adt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_18 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#kw_adt<'i, INHERITED> {}
+        :: pest_typed :: rule ! (r#kw_let , "Corresponds to expression: `(\"let\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_let , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_19 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_let<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_move , "Corresponds to expression: `(\"move\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_move , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_19 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_move , "Corresponds to expression: `(\"move\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_move , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_20 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_move<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Len , "Corresponds to expression: `(\"Len\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Len , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_20 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Len , "Corresponds to expression: `(\"Len\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Len , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_21 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Len<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_PtrToPtr , "Corresponds to expression: `(\"PtrToPtr\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PtrToPtr , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_21 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_PtrToPtr , "Corresponds to expression: `(\"PtrToPtr\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PtrToPtr , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_22 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_PtrToPtr<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_IntToInt , "Corresponds to expression: `(\"IntToInt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_IntToInt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_22 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_IntToInt , "Corresponds to expression: `(\"IntToInt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_IntToInt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_23 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_IntToInt<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Transmute , "Corresponds to expression: `(\"Transmute\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Transmute , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_23 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Transmute , "Corresponds to expression: `(\"Transmute\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Transmute , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_24 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Transmute<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_PointerCoercion , "Corresponds to expression: `(\"PointerCoercion\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PointerCoercion , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_24 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_PointerCoercion , "Corresponds to expression: `(\"PointerCoercion\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PointerCoercion , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_25 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_PointerCoercion<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_copy , "Corresponds to expression: `(\"copy\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_copy , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_25 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_copy , "Corresponds to expression: `(\"copy\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_copy , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_26 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_copy<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Unsize , "Corresponds to expression: `(\"Unsize\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Unsize , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_26 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Unsize , "Corresponds to expression: `(\"Unsize\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Unsize , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_27 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Unsize<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Implicit , "Corresponds to expression: `(\"Implicit\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Implicit , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_27 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Implicit , "Corresponds to expression: `(\"Implicit\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Implicit , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_28 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Implicit<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_PointerExposeProvenance , "Corresponds to expression: `(\"PointerExposeProvenance\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PointerExposeProvenance , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_28 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_PointerExposeProvenance , "Corresponds to expression: `(\"PointerExposeProvenance\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PointerExposeProvenance , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_29 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_PointerExposeProvenance<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_PointerWithExposedProvenance , "Corresponds to expression: `(\"PointerWithExposedProvenance\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PointerWithExposedProvenance , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_29 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_PointerWithExposedProvenance , "Corresponds to expression: `(\"PointerWithExposedProvenance\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PointerWithExposedProvenance , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_30 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_PointerWithExposedProvenance<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Restricted , "Corresponds to expression: `(\"restricted\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Restricted , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_30 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Restricted , "Corresponds to expression: `(\"restricted\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Restricted , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_31 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Restricted<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Add , "Corresponds to expression: `(\"Add\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Add , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_31 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Add , "Corresponds to expression: `(\"Add\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Add , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_32 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Add<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Sub , "Corresponds to expression: `(\"Sub\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Sub , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_32 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Sub , "Corresponds to expression: `(\"Sub\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Sub , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_33 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Sub<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Mul , "Corresponds to expression: `(\"Mul\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Mul , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_33 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Mul , "Corresponds to expression: `(\"Mul\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Mul , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_34 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Mul<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Div , "Corresponds to expression: `(\"Div\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Div , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_34 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Div , "Corresponds to expression: `(\"Div\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Div , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_35 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Div<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Rem , "Corresponds to expression: `(\"Rem\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Rem , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_35 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Rem , "Corresponds to expression: `(\"Rem\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Rem , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_36 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Rem<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Lt , "Corresponds to expression: `(\"Lt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Lt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_36 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Lt , "Corresponds to expression: `(\"Lt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Lt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_37 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Lt<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Le , "Corresponds to expression: `(\"Le\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Le , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_37 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Le , "Corresponds to expression: `(\"Le\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Le , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_38 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Le<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Gt , "Corresponds to expression: `(\"Gt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Gt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_38 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Gt , "Corresponds to expression: `(\"Gt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Gt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_39 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Gt<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Ge , "Corresponds to expression: `(\"Ge\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Ge , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_39 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Ge , "Corresponds to expression: `(\"Ge\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Ge , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_40 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Ge<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Eq , "Corresponds to expression: `(\"Eq\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Eq , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_40 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Eq , "Corresponds to expression: `(\"Eq\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Eq , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_41 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Eq<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Ne , "Corresponds to expression: `(\"Ne\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Ne , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_41 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Ne , "Corresponds to expression: `(\"Ne\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Ne , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_42 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Ne<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_BitAnd , "Corresponds to expression: `(\"BitAnd\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_BitAnd , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_42 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_BitAnd , "Corresponds to expression: `(\"BitAnd\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_BitAnd , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_43 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_BitAnd<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_BitOr , "Corresponds to expression: `(\"BitOr\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_BitOr , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_43 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_BitOr , "Corresponds to expression: `(\"BitOr\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_BitOr , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_44 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_BitOr<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_BitXor , "Corresponds to expression: `(\"BitXor\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_BitXor , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_44 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_BitXor , "Corresponds to expression: `(\"BitXor\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_BitXor , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_45 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_BitXor<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Offset , "Corresponds to expression: `(\"Offset\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Offset , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_45 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Offset , "Corresponds to expression: `(\"Offset\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Offset , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_46 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Offset<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_SizeOf , "Corresponds to expression: `(\"SizeOf\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_SizeOf , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_46 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_SizeOf , "Corresponds to expression: `(\"SizeOf\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_SizeOf , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_47 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_SizeOf<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_AlignOf , "Corresponds to expression: `(\"AlignOf\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_AlignOf , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_47 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_AlignOf , "Corresponds to expression: `(\"AlignOf\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_AlignOf , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_48 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_AlignOf<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Neg , "Corresponds to expression: `(\"Neg\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Neg , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_48 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Neg , "Corresponds to expression: `(\"Neg\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Neg , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_49 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Neg<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Not , "Corresponds to expression: `(\"Not\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Not , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_49 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Not , "Corresponds to expression: `(\"Not\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Not , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_50 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Not<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_PtrMetadata , "Corresponds to expression: `(\"PtrMetadata\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PtrMetadata , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_50 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_PtrMetadata , "Corresponds to expression: `(\"PtrMetadata\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_PtrMetadata , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_51 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_PtrMetadata<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_discriminant , "Corresponds to expression: `(\"discriminant\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_discriminant , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_51 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_discriminant , "Corresponds to expression: `(\"discriminant\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_discriminant , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_52 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_discriminant<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_Ctor , "Corresponds to expression: `(\"Ctor\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Ctor , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_52 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_Ctor , "Corresponds to expression: `(\"Ctor\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_Ctor , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_53 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_Ctor<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_from , "Corresponds to expression: `(\"from\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_from , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_53 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_from , "Corresponds to expression: `(\"from\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_from , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_54 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_from<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_of , "Corresponds to expression: `(\"of\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_of , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_54 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_of , "Corresponds to expression: `(\"of\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_of , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_55 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_of<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_raw , "Corresponds to expression: `(\"raw\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_raw , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_55 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_raw , "Corresponds to expression: `(\"raw\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_raw , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_56 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_raw<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_unreachable , "Corresponds to expression: `(\"unreachable\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_unreachable , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_56 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_unreachable , "Corresponds to expression: `(\"unreachable\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_unreachable , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_57 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_unreachable<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_drop , "Corresponds to expression: `(\"drop\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_drop , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_57 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_drop , "Corresponds to expression: `(\"drop\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_drop , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_58 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_drop<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_break , "Corresponds to expression: `(\"break\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_break , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_58 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_break , "Corresponds to expression: `(\"break\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_break , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_59 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_break<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_continue , "Corresponds to expression: `(\"continue\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_continue , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_59 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_continue , "Corresponds to expression: `(\"continue\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_continue , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_60 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_continue<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_loop , "Corresponds to expression: `(\"loop\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_loop , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_60 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_loop , "Corresponds to expression: `(\"loop\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_loop , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_61 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_loop<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_return , "Corresponds to expression: `(\"return\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_return , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_61 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_return , "Corresponds to expression: `(\"return\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_return , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_62 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_return<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_switchInt , "Corresponds to expression: `(\"switchInt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_switchInt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_62 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_switchInt , "Corresponds to expression: `(\"switchInt\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_switchInt , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_63 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_switchInt<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_true , "Corresponds to expression: `(\"true\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_true , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_63 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_true , "Corresponds to expression: `(\"true\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_true , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_64 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_true<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_false , "Corresponds to expression: `(\"false\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_false , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_64 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_false , "Corresponds to expression: `(\"false\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_false , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_65 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_false<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_unsafe , "Corresponds to expression: `(\"unsafe\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_unsafe , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_65 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_unsafe , "Corresponds to expression: `(\"unsafe\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_unsafe , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_66 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_unsafe<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_pub , "Corresponds to expression: `(\"pub\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_pub , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_66 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_pub , "Corresponds to expression: `(\"pub\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_pub , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_67 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_pub<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_struct , "Corresponds to expression: `(\"struct\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_struct , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_67 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_struct , "Corresponds to expression: `(\"struct\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_struct , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_68 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_struct<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_enum , "Corresponds to expression: `(\"enum\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_enum , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_68 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_enum , "Corresponds to expression: `(\"enum\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_enum , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_69 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_enum<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_impl , "Corresponds to expression: `(\"impl\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_impl , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_69 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_impl , "Corresponds to expression: `(\"impl\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_impl , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_70 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_impl<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_for , "Corresponds to expression: `(\"for\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_for , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_70 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_for , "Corresponds to expression: `(\"for\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_for , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_71 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_for<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_place , "Corresponds to expression: `(\"place\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_place , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_71 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_place , "Corresponds to expression: `(\"place\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_place , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_72 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_place<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_where , "Corresponds to expression: `(\"where\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_where , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_72 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_where , "Corresponds to expression: `(\"where\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_where , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_73 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_where<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_RET , "Corresponds to expression: `(\"RET\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_RET , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_73 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_RET , "Corresponds to expression: `(\"RET\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_RET , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_74 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_RET<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_copy_nonoverlapping , "Corresponds to expression: `(\"copy_nonoverlapping\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_copy_nonoverlapping , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_74 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_copy_nonoverlapping , "Corresponds to expression: `(\"copy_nonoverlapping\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_copy_nonoverlapping , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_75 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_copy_nonoverlapping<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_u8 , "Corresponds to expression: `(\"u8\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u8 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_75 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_u8 , "Corresponds to expression: `(\"u8\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u8 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_76 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_u8<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_u16 , "Corresponds to expression: `(\"u16\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u16 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_76 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_u16 , "Corresponds to expression: `(\"u16\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u16 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_77 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_u16<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_u32 , "Corresponds to expression: `(\"u32\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u32 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_77 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_u32 , "Corresponds to expression: `(\"u32\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u32 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_78 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_u32<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_u64 , "Corresponds to expression: `(\"u64\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u64 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_78 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_u64 , "Corresponds to expression: `(\"u64\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_u64 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_79 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_u64<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_usize , "Corresponds to expression: `(\"usize\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_usize , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_79 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_usize , "Corresponds to expression: `(\"usize\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_usize , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_80 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_usize<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_i8 , "Corresponds to expression: `(\"i8\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i8 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_80 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_i8 , "Corresponds to expression: `(\"i8\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i8 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_81 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_i8<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_i16 , "Corresponds to expression: `(\"i16\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i16 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_81 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_i16 , "Corresponds to expression: `(\"i16\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i16 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_82 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_i16<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_i32 , "Corresponds to expression: `(\"i32\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i32 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_82 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_i32 , "Corresponds to expression: `(\"i32\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i32 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_83 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_i32<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_i64 , "Corresponds to expression: `(\"i64\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i64 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_83 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_i64 , "Corresponds to expression: `(\"i64\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_i64 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_84 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_i64<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_isize , "Corresponds to expression: `(\"isize\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_isize , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_84 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_isize , "Corresponds to expression: `(\"isize\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_isize , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_85 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_isize<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_bool , "Corresponds to expression: `(\"bool\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_bool , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_85 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_bool , "Corresponds to expression: `(\"bool\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_bool , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_86 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_bool<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#kw_str , "Corresponds to expression: `(\"str\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_str , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_86 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#kw_str , "Corresponds to expression: `(\"str\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_str , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_87 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#kw_str<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Keywords , "Corresponds to expression: `(kw_pattern | kw_patt | kw_util | kw_cstr | kw_diag | kw_meta | kw_import | kw_self | kw_Self | kw_fn | kw_mut | kw_const | kw_static | kw_lang | kw_as | kw_crate | kw_use | kw_type | kw_let | kw_move | kw_Len | kw_PtrToPtr | kw_IntToInt | kw_Transmute | kw_PointerCoercion | kw_PointerExposeProvenance | kw_PointerWithExposedProvenance | kw_Add | kw_Sub | kw_Mul | kw_Div | kw_Rem | kw_Lt | kw_Le | kw_Gt | kw_Ge | kw_Eq | kw_Ne | kw_BitAnd | kw_BitOr | kw_BitXor | kw_Offset | kw_SizeOf | kw_AlignOf | kw_Neg | kw_Not | kw_PtrMetadata | kw_discriminant | kw_copy_nonoverlapping | kw_Ctor | kw_from | kw_of | kw_raw | kw_break | kw_continue | kw_loop | kw_return | kw_switchInt | kw_true | kw_false | kw_unsafe | kw_pub | kw_struct | kw_enum | kw_impl | kw_for | kw_where)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Keywords , super :: super :: generics :: Choice67 :: < super :: super :: rules :: r#kw_pattern :: < 'i , 0 > , super :: super :: rules :: r#kw_patt :: < 'i , 0 > , super :: super :: rules :: r#kw_util :: < 'i , 0 > , super :: super :: rules :: r#kw_cstr :: < 'i , 0 > , super :: super :: rules :: r#kw_diag :: < 'i , 0 > , super :: super :: rules :: r#kw_meta :: < 'i , 0 > , super :: super :: rules :: r#kw_import :: < 'i , 0 > , super :: super :: rules :: r#kw_self :: < 'i , 0 > , super :: super :: rules :: r#kw_Self :: < 'i , 0 > , super :: super :: rules :: r#kw_fn :: < 'i , 0 > , super :: super :: rules :: r#kw_mut :: < 'i , 0 > , super :: super :: rules :: r#kw_const :: < 'i , 0 > , super :: super :: rules :: r#kw_static :: < 'i , 0 > , super :: super :: rules :: r#kw_lang :: < 'i , 0 > , super :: super :: rules :: r#kw_as :: < 'i , 0 > , super :: super :: rules :: r#kw_crate :: < 'i , 0 > , super :: super :: rules :: r#kw_use :: < 'i , 0 > , super :: super :: rules :: r#kw_type :: < 'i , 0 > , super :: super :: rules :: r#kw_let :: < 'i , 0 > , super :: super :: rules :: r#kw_move :: < 'i , 0 > , super :: super :: rules :: r#kw_Len :: < 'i , 0 > , super :: super :: rules :: r#kw_PtrToPtr :: < 'i , 0 > , super :: super :: rules :: r#kw_IntToInt :: < 'i , 0 > , super :: super :: rules :: r#kw_Transmute :: < 'i , 0 > , super :: super :: rules :: r#kw_PointerCoercion :: < 'i , 0 > , super :: super :: rules :: r#kw_PointerExposeProvenance :: < 'i , 0 > , super :: super :: rules :: r#kw_PointerWithExposedProvenance :: < 'i , 0 > , super :: super :: rules :: r#kw_Add :: < 'i , 0 > , super :: super :: rules :: r#kw_Sub :: < 'i , 0 > , super :: super :: rules :: r#kw_Mul :: < 'i , 0 > , super :: super :: rules :: r#kw_Div :: < 'i , 0 > , super :: super :: rules :: r#kw_Rem :: < 'i , 0 > , super :: super :: rules :: r#kw_Lt :: < 'i , 0 > , super :: super :: rules :: r#kw_Le :: < 'i , 0 > , super :: super :: rules :: r#kw_Gt :: < 'i , 0 > , super :: super :: rules :: r#kw_Ge :: < 'i , 0 > , super :: super :: rules :: r#kw_Eq :: < 'i , 0 > , super :: super :: rules :: r#kw_Ne :: < 'i , 0 > , super :: super :: rules :: r#kw_BitAnd :: < 'i , 0 > , super :: super :: rules :: r#kw_BitOr :: < 'i , 0 > , super :: super :: rules :: r#kw_BitXor :: < 'i , 0 > , super :: super :: rules :: r#kw_Offset :: < 'i , 0 > , super :: super :: rules :: r#kw_SizeOf :: < 'i , 0 > , super :: super :: rules :: r#kw_AlignOf :: < 'i , 0 > , super :: super :: rules :: r#kw_Neg :: < 'i , 0 > , super :: super :: rules :: r#kw_Not :: < 'i , 0 > , super :: super :: rules :: r#kw_PtrMetadata :: < 'i , 0 > , super :: super :: rules :: r#kw_discriminant :: < 'i , 0 > , super :: super :: rules :: r#kw_copy_nonoverlapping :: < 'i , 0 > , super :: super :: rules :: r#kw_Ctor :: < 'i , 0 > , super :: super :: rules :: r#kw_from :: < 'i , 0 > , super :: super :: rules :: r#kw_of :: < 'i , 0 > , super :: super :: rules :: r#kw_raw :: < 'i , 0 > , super :: super :: rules :: r#kw_break :: < 'i , 0 > , super :: super :: rules :: r#kw_continue :: < 'i , 0 > , super :: super :: rules :: r#kw_loop :: < 'i , 0 > , super :: super :: rules :: r#kw_return :: < 'i , 0 > , super :: super :: rules :: r#kw_switchInt :: < 'i , 0 > , super :: super :: rules :: r#kw_true :: < 'i , 0 > , super :: super :: rules :: r#kw_false :: < 'i , 0 > , super :: super :: rules :: r#kw_unsafe :: < 'i , 0 > , super :: super :: rules :: r#kw_pub :: < 'i , 0 > , super :: super :: rules :: r#kw_struct :: < 'i , 0 > , super :: super :: rules :: r#kw_enum :: < 'i , 0 > , super :: super :: rules :: r#kw_impl :: < 'i , 0 > , super :: super :: rules :: r#kw_for :: < 'i , 0 > , super :: super :: rules :: r#kw_where :: < 'i , 0 > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Keywords<'i, INHERITED> {}
@@ -1565,7 +1582,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#OuterDocComment , "Corresponds to expression: `(\"///\" ~ !\"/\" ~ DocCommentText)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OuterDocComment , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_87 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_88 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DocCommentText :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        :: pest_typed :: rule ! (r#OuterDocComment , "Corresponds to expression: `(\"///\" ~ !\"/\" ~ DocCommentText)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OuterDocComment , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_88 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_89 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DocCommentText :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#OuterDocComment<'i, INHERITED> {
             #[doc = "A helper function to access [`DocCommentText`]."]
             #[allow(non_snake_case)]
@@ -1577,7 +1594,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#InnerDocComment , "Corresponds to expression: `(\"//!\" ~ DocCommentText)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#InnerDocComment , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_89 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DocCommentText :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        :: pest_typed :: rule ! (r#InnerDocComment , "Corresponds to expression: `(\"//!\" ~ DocCommentText)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#InnerDocComment , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_90 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DocCommentText :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#InnerDocComment<'i, INHERITED> {
             #[doc = "A helper function to access [`DocCommentText`]."]
             #[allow(non_snake_case)]
@@ -1591,7 +1608,7 @@ pub mod rules_impl {
         }
         :: pest_typed :: rule ! (r#DocCommentText , "Corresponds to expression: `(!NEWLINE ~ ANY)*`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#DocCommentText , super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#DocCommentText<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LineCommentNonDoc , "Corresponds to expression: `((\"//\" ~ !(\"/\" | \"!\") ~ (!NEWLINE ~ ANY)*) | (\"////\" ~ (!NEWLINE ~ ANY)*))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LineCommentNonDoc , super :: super :: generics :: Choice2 :: < super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_90 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_91 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_92 > , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_93 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
+        :: pest_typed :: rule ! (r#LineCommentNonDoc , "Corresponds to expression: `((\"//\" ~ !(\"/\" | \"!\") ~ (!NEWLINE ~ ANY)*) | (\"////\" ~ (!NEWLINE ~ ANY)*))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LineCommentNonDoc , super :: super :: generics :: Choice2 :: < super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_91 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_92 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_93 > , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_94 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#NEWLINE > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LineCommentNonDoc<'i, INHERITED> {
             #[doc = "A helper function to access [`ANY`]."]
             #[allow(non_snake_case)]
@@ -1649,7 +1666,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#BlockComment , "Corresponds to expression: `(\"/*\" ~ (!\"*/\" ~ ANY)* ~ \"*/\")`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#BlockComment , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_94 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_95 > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_96 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
+        :: pest_typed :: rule ! (r#BlockComment , "Corresponds to expression: `(\"/*\" ~ (!\"*/\" ~ ANY)* ~ \"*/\")`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#BlockComment , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_95 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_96 > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_97 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#BlockComment<'i, INHERITED> {
             #[doc = "A helper function to access [`ANY`]."]
             #[allow(non_snake_case)]
@@ -1700,65 +1717,65 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#WHITESPACE , "Corresponds to expression: `(\" \" | \"\\t\" | \"\\r\" | \"\\n\")`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WHITESPACE , super :: super :: generics :: Choice4 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_97 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_98 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_99 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_100 > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
+        :: pest_typed :: rule ! (r#WHITESPACE , "Corresponds to expression: `(\" \" | \"\\t\" | \"\\r\" | \"\\n\")`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WHITESPACE , super :: super :: generics :: Choice4 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_98 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_99 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_100 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_101 > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Expression , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#WHITESPACE<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LeftBrace , "Corresponds to expression: `\"{\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_101 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LeftBrace , "Corresponds to expression: `\"{\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_102 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LeftBrace<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightBrace , "Corresponds to expression: `\"}\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_102 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightBrace , "Corresponds to expression: `\"}\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBrace , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_103 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightBrace<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LeftBracket , "Corresponds to expression: `\"[\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_103 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LeftBracket , "Corresponds to expression: `\"[\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_104 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LeftBracket<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightBracket , "Corresponds to expression: `\"]\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_104 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightBracket , "Corresponds to expression: `\"]\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightBracket , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_105 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightBracket<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LeftParen , "Corresponds to expression: `\"(\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_105 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LeftParen , "Corresponds to expression: `\"(\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LeftParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_106 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LeftParen<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightParen , "Corresponds to expression: `\")\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_106 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightParen , "Corresponds to expression: `\")\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightParen , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_107 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightParen<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#LessThan , "Corresponds to expression: `\"<\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LessThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_107 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#LessThan , "Corresponds to expression: `\"<\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#LessThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_108 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#LessThan<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#GreaterThan , "Corresponds to expression: `\">\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#GreaterThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_108 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#GreaterThan , "Corresponds to expression: `\">\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#GreaterThan , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_109 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#GreaterThan<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Dollar , "Corresponds to expression: `\"$\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dollar , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_109 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Dollar , "Corresponds to expression: `\"$\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dollar , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_110 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Dollar<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Assign , "Corresponds to expression: `\"=\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Assign , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_110 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Assign , "Corresponds to expression: `\"=\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Assign , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_111 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Assign<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Comma , "Corresponds to expression: `\",\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Comma , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_111 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Comma , "Corresponds to expression: `\",\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Comma , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_112 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Comma<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Dot , "Corresponds to expression: `\".\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_112 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Dot , "Corresponds to expression: `\".\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_113 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Dot<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Dot2 , "Corresponds to expression: `\"..\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_113 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Dot2 , "Corresponds to expression: `\"..\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Dot2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_114 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Dot2<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Colon , "Corresponds to expression: `\":\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_114 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Colon , "Corresponds to expression: `\":\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_115 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Colon<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Colon2 , "Corresponds to expression: `\"::\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_115 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Colon2 , "Corresponds to expression: `\"::\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Colon2 , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_116 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Colon2<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#SemiColon , "Corresponds to expression: `\";\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#SemiColon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_116 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#SemiColon , "Corresponds to expression: `\";\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#SemiColon , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_117 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#SemiColon<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Hash , "Corresponds to expression: `\"#\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Hash , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_117 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Hash , "Corresponds to expression: `\"#\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Hash , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_118 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Hash<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#And , "Corresponds to expression: `\"&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#And , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_118 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#And , "Corresponds to expression: `\"&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#And , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_119 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#And<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#AndAnd , "Corresponds to expression: `\"&&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#AndAnd , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_119 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#AndAnd , "Corresponds to expression: `\"&&\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#AndAnd , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_120 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#AndAnd<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#OrOr , "Corresponds to expression: `\"||\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OrOr , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_120 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#OrOr , "Corresponds to expression: `\"||\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OrOr , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_121 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#OrOr<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Bang , "Corresponds to expression: `\"!\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Bang , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_121 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Bang , "Corresponds to expression: `\"!\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Bang , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_122 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Bang<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Question , "Corresponds to expression: `\"?\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Question , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_122 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Question , "Corresponds to expression: `\"?\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Question , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_123 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Question<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Star , "Corresponds to expression: `\"*\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Star , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_123 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Star , "Corresponds to expression: `\"*\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Star , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_124 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Star<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Arrow , "Corresponds to expression: `\"->\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Arrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_124 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Arrow , "Corresponds to expression: `\"->\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Arrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_125 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Arrow<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#RightArrow , "Corresponds to expression: `\"=>\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightArrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_125 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#RightArrow , "Corresponds to expression: `\"=>\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RightArrow , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_126 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RightArrow<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Quote , "Corresponds to expression: `\"'\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Quote , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_126 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Quote , "Corresponds to expression: `\"'\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Quote , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_127 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Quote<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Plus , "Corresponds to expression: `\"+\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Plus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_127 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Plus , "Corresponds to expression: `\"+\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Plus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_128 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Plus<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#Minus , "Corresponds to expression: `\"-\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Minus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_128 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#Minus , "Corresponds to expression: `\"-\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Minus , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_129 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Minus<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#PlaceHolder , "Corresponds to expression: `\"_\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#PlaceHolder , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_129 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#PlaceHolder , "Corresponds to expression: `\"_\"`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#PlaceHolder , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_130 > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#PlaceHolder<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Literal , "Corresponds to expression: `(Integer | String | Bool)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Literal , super :: super :: generics :: Choice3 :: < super :: super :: rules :: r#Integer :: < 'i , INHERITED > , super :: super :: rules :: r#String :: < 'i , INHERITED > , super :: super :: rules :: r#Bool :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Literal<'i, INHERITED> {
@@ -1804,13 +1821,13 @@ pub mod rules_impl {
         impl<'i, const INHERITED: ::core::primitive::usize> r#DEC_DIGIT<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#HEX_DIGIT , "Corresponds to expression: `(('0'..'9') | ('a'..'f') | ('A'..'F'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#HEX_DIGIT , super :: super :: generics :: Choice3 :: < super :: super :: generics :: CharRange :: < '0' , '9' > , super :: super :: generics :: CharRange :: < 'a' , 'f' > , super :: super :: generics :: CharRange :: < 'A' , 'F' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#HEX_DIGIT<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#DEC_LITERAL , "Corresponds to expression: `(DEC_DIGIT ~ (DEC_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#DEC_LITERAL , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_130 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#DEC_LITERAL , "Corresponds to expression: `(DEC_DIGIT ~ (DEC_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#DEC_LITERAL , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#DEC_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_131 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#DEC_LITERAL<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#BIN_LITERAL , "Corresponds to expression: `(\"0b\" ~ (BIN_DIGIT | \"_\")* ~ BIN_DIGIT ~ (BIN_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#BIN_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_131 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_132 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_133 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#BIN_LITERAL , "Corresponds to expression: `(\"0b\" ~ (BIN_DIGIT | \"_\")* ~ BIN_DIGIT ~ (BIN_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#BIN_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_132 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_133 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#BIN_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_134 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#BIN_LITERAL<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#OCT_LITERAL , "Corresponds to expression: `(\"0o\" ~ (OCT_DIGIT | \"_\")* ~ OCT_DIGIT ~ (OCT_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OCT_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_134 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_135 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_136 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#OCT_LITERAL , "Corresponds to expression: `(\"0o\" ~ (OCT_DIGIT | \"_\")* ~ OCT_DIGIT ~ (OCT_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#OCT_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_135 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_136 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#OCT_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_137 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#OCT_LITERAL<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#HEX_LITERAL , "Corresponds to expression: `(\"0x\" ~ (HEX_DIGIT | \"_\")* ~ HEX_DIGIT ~ (HEX_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#HEX_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_137 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_138 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_139 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#HEX_LITERAL , "Corresponds to expression: `(\"0x\" ~ (HEX_DIGIT | \"_\")* ~ HEX_DIGIT ~ (HEX_DIGIT | \"_\")*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#HEX_LITERAL , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_138 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_139 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#HEX_DIGIT :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_140 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#HEX_LITERAL<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#IntegerSuffix , "Corresponds to expression: `(kw_u8 | kw_u16 | kw_u32 | kw_u64 | kw_usize | kw_i8 | kw_i16 | kw_i32 | kw_i64 | kw_isize)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#IntegerSuffix , super :: super :: generics :: Choice10 :: < super :: super :: rules :: r#kw_u8 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_u16 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_u32 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_u64 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_usize :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i8 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i16 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i32 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_i64 :: < 'i , INHERITED > , super :: super :: rules :: r#kw_isize :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#IntegerSuffix<'i, INHERITED> {
@@ -2134,7 +2151,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#String , "Corresponds to expression: `(\"\\\"\" ~ (!(\"\\\"\") ~ ANY)* ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#String , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_140 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Skip :: < super :: super :: constant_wrappers :: r#w_141 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_142 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#String , "Corresponds to expression: `(\"\\\"\" ~ (!(\"\\\"\") ~ ANY)* ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#String , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_141 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Skip :: < super :: super :: constant_wrappers :: r#w_142 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_143 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#String<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Bool , "Corresponds to expression: `(kw_true | kw_false)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Bool , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#kw_true :: < 'i , INHERITED > , super :: super :: rules :: r#kw_false :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Bool<'i, INHERITED> {
@@ -2163,7 +2180,7 @@ pub mod rules_impl {
         }
         :: pest_typed :: rule ! (r#WordLeading , "Corresponds to expression: `(('a'..'z') | ('A'..'Z') | ('一'..'龥') | ('_'..'_'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WordLeading , super :: super :: generics :: Choice4 :: < super :: super :: generics :: CharRange :: < 'a' , 'z' > , super :: super :: generics :: CharRange :: < 'A' , 'Z' > , super :: super :: generics :: CharRange :: < '一' , '龥' > , super :: super :: generics :: CharRange :: < '_' , '_' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#WordLeading<'i, INHERITED> {}
-        :: pest_typed :: rule ! (r#WordFollowing , "Corresponds to expression: `(WordLeading | \"_\" | \"-\" | ('0'..'9'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WordFollowing , super :: super :: generics :: Choice4 :: < super :: super :: rules :: r#WordLeading :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_143 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_144 > , super :: super :: generics :: CharRange :: < '0' , '9' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#WordFollowing , "Corresponds to expression: `(WordLeading | \"_\" | \"-\" | ('0'..'9'))`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#WordFollowing , super :: super :: generics :: Choice4 :: < super :: super :: rules :: r#WordLeading :: < 'i , 0 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_144 > , super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_145 > , super :: super :: generics :: CharRange :: < '0' , '9' > , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#WordFollowing<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#Word , "Corresponds to expression: `(WordLeading ~ WordFollowing*)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Word , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#WordLeading :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Word<'i, INHERITED> {}
@@ -2192,7 +2209,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#MetaVariableType , "Corresponds to expression: `(kw_type | (kw_const ~ LeftParen ~ Type ~ RightParen) | (kw_place ~ LeftParen ~ Type ~ RightParen))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#MetaVariableType , super :: super :: generics :: Choice3 :: < super :: super :: rules :: r#kw_type :: < 'i , INHERITED > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_const :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_place :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#MetaVariableType , "Corresponds to expression: `(kw_type | kw_adt | (kw_const ~ LeftParen ~ Type ~ RightParen) | (kw_place ~ LeftParen ~ Type ~ RightParen))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#MetaVariableType , super :: super :: generics :: Choice4 :: < super :: super :: rules :: r#kw_type :: < 'i , INHERITED > , super :: super :: rules :: r#kw_adt :: < 'i , INHERITED > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_const :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_place :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#MetaVariableType<'i, INHERITED> {
             #[doc = "A helper function to access [`LeftParen`]."]
             #[allow(non_snake_case)]
@@ -2206,14 +2223,14 @@ pub mod rules_impl {
                 {
                     let res = (
                         {
-                            let res = res._1().map(|res| {
+                            let res = res._2().map(|res| {
                                 let res = &res.content.1.matched;
                                 res
                             });
                             res
                         },
                         {
-                            let res = res._2().map(|res| {
+                            let res = res._3().map(|res| {
                                 let res = &res.content.1.matched;
                                 res
                             });
@@ -2235,14 +2252,14 @@ pub mod rules_impl {
                 {
                     let res = (
                         {
-                            let res = res._1().map(|res| {
+                            let res = res._2().map(|res| {
                                 let res = &res.content.3.matched;
                                 res
                             });
                             res
                         },
                         {
-                            let res = res._2().map(|res| {
+                            let res = res._3().map(|res| {
                                 let res = &res.content.3.matched;
                                 res
                             });
@@ -2264,20 +2281,31 @@ pub mod rules_impl {
                 {
                     let res = (
                         {
-                            let res = res._1().map(|res| {
-                                let res = &res.content.2.matched;
-                                res
-                            });
-                            res
-                        },
-                        {
                             let res = res._2().map(|res| {
                                 let res = &res.content.2.matched;
                                 res
                             });
                             res
                         },
+                        {
+                            let res = res._3().map(|res| {
+                                let res = &res.content.2.matched;
+                                res
+                            });
+                            res
+                        },
                     );
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`kw_adt`]."]
+            #[allow(non_snake_case)]
+            pub fn r#kw_adt<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#kw_adt<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = res._1().map(|res| res);
                     res
                 }
             }
@@ -2288,7 +2316,7 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#kw_const<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = res._1().map(|res| {
+                    let res = res._2().map(|res| {
                         let res = &res.content.0.matched;
                         res
                     });
@@ -2302,7 +2330,7 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#kw_place<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = res._2().map(|res| {
+                    let res = res._3().map(|res| {
                         let res = &res.content.0.matched;
                         res
                     });
@@ -4089,7 +4117,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#TypeGroup , "Corresponds to expression: `(\"Group\" ~ Type)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#TypeGroup , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_145 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#TypeGroup , "Corresponds to expression: `(\"Group\" ~ Type)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#TypeGroup , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_146 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#TypeGroup<'i, INHERITED> {
             #[doc = "A helper function to access [`Type`]."]
             #[allow(non_snake_case)]
@@ -8853,8 +8881,83 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#Struct , "Corresponds to expression: `(kw_pub? ~ kw_struct ~ MetaVariable ~ LeftBrace ~ FieldsSeparatedByComma? ~ RightBrace)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Struct , super :: super :: generics :: Seq6 :: < (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#kw_pub :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_struct :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#MetaVariable :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#FieldsSeparatedByComma :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
-        impl<'i, const INHERITED: ::core::primitive::usize> r#Struct<'i, INHERITED> {
+        :: pest_typed :: rule ! (r#NonExhaustiveFields , "Corresponds to expression: `((Field ~ Comma)* ~ Dot2 ~ Comma?)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#NonExhaustiveFields , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Field :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Comma :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Dot2 :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#Comma :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#NonExhaustiveFields<'i, INHERITED> {
+            #[doc = "A helper function to access [`Comma`]."]
+            #[allow(non_snake_case)]
+            pub fn r#Comma<'s>(
+                &'s self,
+            ) -> (
+                ::pest_typed::re_exported::Vec<&'s super::super::rules::r#Comma<'i, INHERITED>>,
+                ::pest_typed::re_exported::Option<&'s super::super::rules::r#Comma<'i, INHERITED>>,
+            ) {
+                let res = &*self.content;
+                {
+                    let res = (
+                        {
+                            let res = &res.content.0.matched;
+                            {
+                                let res = res
+                                    .content
+                                    .iter()
+                                    .map(|res| {
+                                        let res = &res.matched;
+                                        {
+                                            let res = &res.content.1.matched;
+                                            res
+                                        }
+                                    })
+                                    .collect::<::pest_typed::re_exported::Vec<_>>();
+                                res
+                            }
+                        },
+                        {
+                            let res = &res.content.2.matched;
+                            {
+                                let res = res.as_ref().map(|res| res);
+                                res
+                            }
+                        },
+                    );
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`Dot2`]."]
+            #[allow(non_snake_case)]
+            pub fn r#Dot2<'s>(&'s self) -> &'s super::super::rules::r#Dot2<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.1.matched;
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`Field`]."]
+            #[allow(non_snake_case)]
+            pub fn r#Field<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#Field<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    {
+                        let res = res
+                            .content
+                            .iter()
+                            .map(|res| {
+                                let res = &res.matched;
+                                {
+                                    let res = &res.content.0.matched;
+                                    res
+                                }
+                            })
+                            .collect::<::pest_typed::re_exported::Vec<_>>();
+                        res
+                    }
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#StructFields , "Corresponds to expression: `(NonExhaustiveFields | FieldsSeparatedByComma)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#StructFields , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#NonExhaustiveFields :: < 'i , INHERITED > , super :: super :: rules :: r#FieldsSeparatedByComma :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#StructFields<'i, INHERITED> {
             #[doc = "A helper function to access [`FieldsSeparatedByComma`]."]
             #[allow(non_snake_case)]
             pub fn r#FieldsSeparatedByComma<'s>(
@@ -8863,7 +8966,64 @@ pub mod rules_impl {
             {
                 let res = &*self.content;
                 {
-                    let res = &res.content.4.matched;
+                    let res = res._1().map(|res| res);
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`NonExhaustiveFields`]."]
+            #[allow(non_snake_case)]
+            pub fn r#NonExhaustiveFields<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#NonExhaustiveFields<'i, INHERITED>>
+            {
+                let res = &*self.content;
+                {
+                    let res = res._0().map(|res| res);
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#ItemGenericWildcard , "Corresponds to expression: `(LessThan ~ Dot2 ~ GreaterThan)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#ItemGenericWildcard , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LessThan :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Dot2 :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#GreaterThan :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#ItemGenericWildcard<'i, INHERITED> {
+            #[doc = "A helper function to access [`Dot2`]."]
+            #[allow(non_snake_case)]
+            pub fn r#Dot2<'s>(&'s self) -> &'s super::super::rules::r#Dot2<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.1.matched;
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`GreaterThan`]."]
+            #[allow(non_snake_case)]
+            pub fn r#GreaterThan<'s>(&'s self) -> &'s super::super::rules::r#GreaterThan<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.2.matched;
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`LessThan`]."]
+            #[allow(non_snake_case)]
+            pub fn r#LessThan<'s>(&'s self) -> &'s super::super::rules::r#LessThan<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#Struct , "Corresponds to expression: `(kw_pub? ~ kw_struct ~ MetaVariable ~ ItemGenericWildcard? ~ LeftBrace ~ StructFields? ~ RightBrace)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Struct , super :: super :: generics :: Seq7 :: < (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#kw_pub :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_struct :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#MetaVariable :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#ItemGenericWildcard :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#StructFields :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#Struct<'i, INHERITED> {
+            #[doc = "A helper function to access [`ItemGenericWildcard`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ItemGenericWildcard<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#ItemGenericWildcard<'i, INHERITED>>
+            {
+                let res = &*self.content;
+                {
+                    let res = &res.content.3.matched;
                     {
                         let res = res.as_ref().map(|res| res);
                         res
@@ -8875,7 +9035,7 @@ pub mod rules_impl {
             pub fn r#LeftBrace<'s>(&'s self) -> &'s super::super::rules::r#LeftBrace<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.3.matched;
+                    let res = &res.content.4.matched;
                     res
                 }
             }
@@ -8893,8 +9053,22 @@ pub mod rules_impl {
             pub fn r#RightBrace<'s>(&'s self) -> &'s super::super::rules::r#RightBrace<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.5.matched;
+                    let res = &res.content.6.matched;
                     res
+                }
+            }
+            #[doc = "A helper function to access [`StructFields`]."]
+            #[allow(non_snake_case)]
+            pub fn r#StructFields<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#StructFields<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.5.matched;
+                    {
+                        let res = res.as_ref().map(|res| res);
+                        res
+                    }
                 }
             }
             #[doc = "A helper function to access [`kw_pub`]."]
@@ -9202,14 +9376,104 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#Impl , "Corresponds to expression: `(kw_unsafe? ~ kw_impl ~ ImplKind? ~ Type ~ LeftBrace ~ (Fn ~ WhereBlock?)* ~ RightBrace)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Impl , super :: super :: generics :: Seq7 :: < (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#kw_unsafe :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_impl :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#ImplKind :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Fn :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#WhereBlock :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#ItemBinding , "Corresponds to expression: `(MetaVariable ~ Colon)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#ItemBinding , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#MetaVariable :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Colon :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#ItemBinding<'i, INHERITED> {
+            #[doc = "A helper function to access [`Colon`]."]
+            #[allow(non_snake_case)]
+            pub fn r#Colon<'s>(&'s self) -> &'s super::super::rules::r#Colon<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.1.matched;
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`MetaVariable`]."]
+            #[allow(non_snake_case)]
+            pub fn r#MetaVariable<'s>(&'s self) -> &'s super::super::rules::r#MetaVariable<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#ItemAdtType , "Corresponds to expression: `(MetaVariable ~ ItemGenericWildcard)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#ItemAdtType , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#MetaVariable :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ItemGenericWildcard :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#ItemAdtType<'i, INHERITED> {
+            #[doc = "A helper function to access [`ItemGenericWildcard`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ItemGenericWildcard<'s>(
+                &'s self,
+            ) -> &'s super::super::rules::r#ItemGenericWildcard<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.1.matched;
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`MetaVariable`]."]
+            #[allow(non_snake_case)]
+            pub fn r#MetaVariable<'s>(&'s self) -> &'s super::super::rules::r#MetaVariable<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#ImplSelfType , "Corresponds to expression: `(ItemAdtType | Type)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#ImplSelfType , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#ItemAdtType :: < 'i , INHERITED > , super :: super :: rules :: r#Type :: < 'i , INHERITED > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#ImplSelfType<'i, INHERITED> {
+            #[doc = "A helper function to access [`ItemAdtType`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ItemAdtType<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#ItemAdtType<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = res._0().map(|res| res);
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`Type`]."]
+            #[allow(non_snake_case)]
+            pub fn r#Type<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#Type<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = res._1().map(|res| res);
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#ImplWhereClause , "Corresponds to expression: `(kw_where ~ Dot2)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#ImplWhereClause , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_where :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Dot2 :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#ImplWhereClause<'i, INHERITED> {
+            #[doc = "A helper function to access [`Dot2`]."]
+            #[allow(non_snake_case)]
+            pub fn r#Dot2<'s>(&'s self) -> &'s super::super::rules::r#Dot2<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.1.matched;
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`kw_where`]."]
+            #[allow(non_snake_case)]
+            pub fn r#kw_where<'s>(&'s self) -> &'s super::super::rules::r#kw_where<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    res
+                }
+            }
+        }
+        :: pest_typed :: rule ! (r#Impl , "Corresponds to expression: `(ItemBinding? ~ kw_unsafe? ~ kw_impl ~ ItemGenericWildcard? ~ ImplKind? ~ ImplSelfType ~ ImplWhereClause? ~ LeftBrace ~ (Fn ~ WhereBlock?)* ~ RightBrace)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#Impl , super :: super :: generics :: Seq10 :: < (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#ItemBinding :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#kw_unsafe :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_impl :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#ItemGenericWildcard :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#ImplKind :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ImplSelfType :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#ImplWhereClause :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Rep :: < 'i , INHERITED , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Fn :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#WhereBlock :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#Impl<'i, INHERITED> {
             #[doc = "A helper function to access [`Fn`]."]
             #[allow(non_snake_case)]
             pub fn r#Fn<'s>(&'s self) -> ::pest_typed::re_exported::Vec<&'s super::super::rules::r#Fn<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.5.matched;
+                    let res = &res.content.8.matched;
                     {
                         let res = res
                             .content
@@ -9233,7 +9497,60 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#ImplKind<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.2.matched;
+                    let res = &res.content.4.matched;
+                    {
+                        let res = res.as_ref().map(|res| res);
+                        res
+                    }
+                }
+            }
+            #[doc = "A helper function to access [`ImplSelfType`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ImplSelfType<'s>(&'s self) -> &'s super::super::rules::r#ImplSelfType<'i, INHERITED> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.5.matched;
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`ImplWhereClause`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ImplWhereClause<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#ImplWhereClause<'i, INHERITED>>
+            {
+                let res = &*self.content;
+                {
+                    let res = &res.content.6.matched;
+                    {
+                        let res = res.as_ref().map(|res| res);
+                        res
+                    }
+                }
+            }
+            #[doc = "A helper function to access [`ItemBinding`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ItemBinding<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#ItemBinding<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.0.matched;
+                    {
+                        let res = res.as_ref().map(|res| res);
+                        res
+                    }
+                }
+            }
+            #[doc = "A helper function to access [`ItemGenericWildcard`]."]
+            #[allow(non_snake_case)]
+            pub fn r#ItemGenericWildcard<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#ItemGenericWildcard<'i, INHERITED>>
+            {
+                let res = &*self.content;
+                {
+                    let res = &res.content.3.matched;
                     {
                         let res = res.as_ref().map(|res| res);
                         res
@@ -9245,7 +9562,7 @@ pub mod rules_impl {
             pub fn r#LeftBrace<'s>(&'s self) -> &'s super::super::rules::r#LeftBrace<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.4.matched;
+                    let res = &res.content.7.matched;
                     res
                 }
             }
@@ -9254,16 +9571,7 @@ pub mod rules_impl {
             pub fn r#RightBrace<'s>(&'s self) -> &'s super::super::rules::r#RightBrace<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.6.matched;
-                    res
-                }
-            }
-            #[doc = "A helper function to access [`Type`]."]
-            #[allow(non_snake_case)]
-            pub fn r#Type<'s>(&'s self) -> &'s super::super::rules::r#Type<'i, INHERITED> {
-                let res = &*self.content;
-                {
-                    let res = &res.content.3.matched;
+                    let res = &res.content.9.matched;
                     res
                 }
             }
@@ -9276,7 +9584,7 @@ pub mod rules_impl {
             > {
                 let res = &*self.content;
                 {
-                    let res = &res.content.5.matched;
+                    let res = &res.content.8.matched;
                     {
                         let res = res
                             .content
@@ -9301,7 +9609,7 @@ pub mod rules_impl {
             pub fn r#kw_impl<'s>(&'s self) -> &'s super::super::rules::r#kw_impl<'i, INHERITED> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.1.matched;
+                    let res = &res.content.2.matched;
                     res
                 }
             }
@@ -9312,7 +9620,7 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#kw_unsafe<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = &res.content.0.matched;
+                    let res = &res.content.1.matched;
                     {
                         let res = res.as_ref().map(|res| res);
                         res
@@ -9414,7 +9722,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#RustItemsWithConstraint , "Corresponds to expression: `(LeftBrace ~ RustItemWithConstraint+ ~ RightBrace)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RustItemsWithConstraint , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: RepOnce :: < 'i , INHERITED , super :: super :: rules :: r#RustItemWithConstraint :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#RustItemsWithConstraint , "Corresponds to expression: `(LeftBrace ~ RustItemWithConstraint+ ~ RightBrace ~ WhereBlock?)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#RustItemsWithConstraint , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: RepOnce :: < 'i , INHERITED , super :: super :: rules :: r#RustItemWithConstraint :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightBrace :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < :: pest_typed :: re_exported :: Option :: < super :: super :: rules :: r#WhereBlock :: < 'i , INHERITED > > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#RustItemsWithConstraint<'i, INHERITED> {
             #[doc = "A helper function to access [`LeftBrace`]."]
             #[allow(non_snake_case)]
@@ -9452,6 +9760,20 @@ pub mod rules_impl {
                                 res
                             })
                             .collect::<::pest_typed::re_exported::Vec<_>>();
+                        res
+                    }
+                }
+            }
+            #[doc = "A helper function to access [`WhereBlock`]."]
+            #[allow(non_snake_case)]
+            pub fn r#WhereBlock<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#WhereBlock<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = &res.content.3.matched;
+                    {
+                        let res = res.as_ref().map(|res| res);
                         res
                     }
                 }
@@ -9903,7 +10225,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#diagMessageText , "Corresponds to expression: `(!(\"\\\"\" | LeftBrace) ~ ANY)+`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageText , super :: super :: generics :: RepOnce :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_146 > , super :: super :: rules :: r#LeftBrace :: < 'i , 0 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#diagMessageText , "Corresponds to expression: `(!(\"\\\"\" | LeftBrace) ~ ANY)+`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageText , super :: super :: generics :: RepOnce :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_147 > , super :: super :: rules :: r#LeftBrace :: < 'i , 0 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessageText<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#diagMessageInner , "Corresponds to expression: `(diagMessageArg | diagMessageText)*`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageInner , super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#diagMessageArg :: < 'i , 0 > , super :: super :: rules :: r#diagMessageText :: < 'i , 0 > , > > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessageInner<'i, INHERITED> {
@@ -9954,7 +10276,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#diagMessage , "Corresponds to expression: `(\"\\\"\" ~ diagMessageInner ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessage , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_147 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagMessageInner :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_148 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        :: pest_typed :: rule ! (r#diagMessage , "Corresponds to expression: `(\"\\\"\" ~ diagMessageInner ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessage , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_148 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagMessageInner :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_149 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessage<'i, INHERITED> {
             #[doc = "A helper function to access [`diagMessageInner`]."]
             #[allow(non_snake_case)]
@@ -10772,7 +11094,7 @@ pub mod generics {
         ::pest_typed::choices::Choice2<super::rules::WHITESPACE<'i, 0>, super::rules::COMMENT<'i, 0>>,
     >;
     pub use pest_typed::choices::{Choice2, Choice3, Choice4, Choice5, Choice6, Choice9, Choice10};
-    pub use pest_typed::sequence::{Seq2, Seq3, Seq4, Seq5, Seq6, Seq7, Seq8, Seq9};
+    pub use pest_typed::sequence::{Seq2, Seq3, Seq4, Seq5, Seq6, Seq7, Seq8, Seq9, Seq10};
     pub use predefined_node::{CharRange, Insens, Negative, PeekSlice1, PeekSlice2, Positive, Push, Skip, Str};
     pest_typed::choices!(
         Choice12, choice12, 12usize, T0, _0, T1, _1, T2, _2, T3, _3, T4, _4, T5, _5, T6, _6, T7, _7, T8, _8, T9, _9,

--- a/crates/rpl_parser/src/parser.rs
+++ b/crates/rpl_parser/src/parser.rs
@@ -152,6 +152,7 @@ pub enum Rule {
     r#Identifier,
     r#LabelName,
     r#MetaVariable,
+    r#kw_access,
     r#MetaVariableType,
     r#Predicate,
     r#PredicateTerm,
@@ -1344,19 +1345,19 @@ mod constant_wrappers {
     impl ::pest_typed::StringWrapper for r#w_145 {
         const CONTENT: &'static ::core::primitive::str = "-";
     }
-    #[doc = "A wrapper for `\"Group\"`."]
+    #[doc = "A wrapper for `\"access\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_146;
     impl ::pest_typed::StringWrapper for r#w_146 {
-        const CONTENT: &'static ::core::primitive::str = "Group";
+        const CONTENT: &'static ::core::primitive::str = "access";
     }
-    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[doc = "A wrapper for `\"Group\"`."]
     #[allow(non_camel_case_types)]
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_147;
     impl ::pest_typed::StringWrapper for r#w_147 {
-        const CONTENT: &'static ::core::primitive::str = "\"";
+        const CONTENT: &'static ::core::primitive::str = "Group";
     }
     #[doc = "A wrapper for `\"\\\"\"`."]
     #[allow(non_camel_case_types)]
@@ -1370,6 +1371,13 @@ mod constant_wrappers {
     #[derive(Clone, Hash, PartialEq, Eq)]
     pub struct r#w_149;
     impl ::pest_typed::StringWrapper for r#w_149 {
+        const CONTENT: &'static ::core::primitive::str = "\"";
+    }
+    #[doc = "A wrapper for `\"\\\"\"`."]
+    #[allow(non_camel_case_types)]
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct r#w_150;
+    impl ::pest_typed::StringWrapper for r#w_150 {
         const CONTENT: &'static ::core::primitive::str = "\"";
     }
 }
@@ -2209,7 +2217,9 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#MetaVariableType , "Corresponds to expression: `(kw_type | kw_adt | (kw_const ~ LeftParen ~ Type ~ RightParen) | (kw_place ~ LeftParen ~ Type ~ RightParen))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#MetaVariableType , super :: super :: generics :: Choice4 :: < super :: super :: rules :: r#kw_type :: < 'i , INHERITED > , super :: super :: rules :: r#kw_adt :: < 'i , INHERITED > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_const :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_place :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#kw_access , "Corresponds to expression: `(\"access\" ~ !WordFollowing)`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#kw_access , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_146 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: rules :: r#WordFollowing :: < 'i , 0 > > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        impl<'i, const INHERITED: ::core::primitive::usize> r#kw_access<'i, INHERITED> {}
+        :: pest_typed :: rule ! (r#MetaVariableType , "Corresponds to expression: `(kw_type | kw_adt | kw_access | (kw_const ~ LeftParen ~ Type ~ RightParen) | (kw_place ~ LeftParen ~ Type ~ RightParen))`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#MetaVariableType , super :: super :: generics :: Choice5 :: < super :: super :: rules :: r#kw_type :: < 'i , INHERITED > , super :: super :: rules :: r#kw_adt :: < 'i , INHERITED > , super :: super :: rules :: r#kw_access :: < 'i , INHERITED > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_const :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Seq4 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#kw_place :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#LeftParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#RightParen :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#MetaVariableType<'i, INHERITED> {
             #[doc = "A helper function to access [`LeftParen`]."]
             #[allow(non_snake_case)]
@@ -2223,14 +2233,14 @@ pub mod rules_impl {
                 {
                     let res = (
                         {
-                            let res = res._2().map(|res| {
+                            let res = res._3().map(|res| {
                                 let res = &res.content.1.matched;
                                 res
                             });
                             res
                         },
                         {
-                            let res = res._3().map(|res| {
+                            let res = res._4().map(|res| {
                                 let res = &res.content.1.matched;
                                 res
                             });
@@ -2252,14 +2262,14 @@ pub mod rules_impl {
                 {
                     let res = (
                         {
-                            let res = res._2().map(|res| {
+                            let res = res._3().map(|res| {
                                 let res = &res.content.3.matched;
                                 res
                             });
                             res
                         },
                         {
-                            let res = res._3().map(|res| {
+                            let res = res._4().map(|res| {
                                 let res = &res.content.3.matched;
                                 res
                             });
@@ -2281,20 +2291,31 @@ pub mod rules_impl {
                 {
                     let res = (
                         {
-                            let res = res._2().map(|res| {
-                                let res = &res.content.2.matched;
-                                res
-                            });
-                            res
-                        },
-                        {
                             let res = res._3().map(|res| {
                                 let res = &res.content.2.matched;
                                 res
                             });
                             res
                         },
+                        {
+                            let res = res._4().map(|res| {
+                                let res = &res.content.2.matched;
+                                res
+                            });
+                            res
+                        },
                     );
+                    res
+                }
+            }
+            #[doc = "A helper function to access [`kw_access`]."]
+            #[allow(non_snake_case)]
+            pub fn r#kw_access<'s>(
+                &'s self,
+            ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#kw_access<'i, INHERITED>> {
+                let res = &*self.content;
+                {
+                    let res = res._2().map(|res| res);
                     res
                 }
             }
@@ -2316,7 +2337,7 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#kw_const<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = res._2().map(|res| {
+                    let res = res._3().map(|res| {
                         let res = &res.content.0.matched;
                         res
                     });
@@ -2330,7 +2351,7 @@ pub mod rules_impl {
             ) -> ::pest_typed::re_exported::Option<&'s super::super::rules::r#kw_place<'i, INHERITED>> {
                 let res = &*self.content;
                 {
-                    let res = res._3().map(|res| {
+                    let res = res._4().map(|res| {
                         let res = &res.content.0.matched;
                         res
                     });
@@ -4117,7 +4138,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#TypeGroup , "Corresponds to expression: `(\"Group\" ~ Type)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#TypeGroup , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_146 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
+        :: pest_typed :: rule ! (r#TypeGroup , "Corresponds to expression: `(\"Group\" ~ Type)`. Normal rule." "" , super :: super :: Rule , super :: super :: Rule :: r#TypeGroup , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_147 > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#Type :: < 'i , INHERITED > , super :: super :: generics :: Skipped < 'i > , INHERITED >) , > , super :: super :: generics :: Skipped :: < 'i > , INHERITED , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#TypeGroup<'i, INHERITED> {
             #[doc = "A helper function to access [`Type`]."]
             #[allow(non_snake_case)]
@@ -10225,7 +10246,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#diagMessageText , "Corresponds to expression: `(!(\"\\\"\" | LeftBrace) ~ ANY)+`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageText , super :: super :: generics :: RepOnce :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_147 > , super :: super :: rules :: r#LeftBrace :: < 'i , 0 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
+        :: pest_typed :: rule ! (r#diagMessageText , "Corresponds to expression: `(!(\"\\\"\" | LeftBrace) ~ ANY)+`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageText , super :: super :: generics :: RepOnce :: < 'i , 0 , super :: super :: generics :: Seq2 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Negative :: < super :: super :: generics :: Choice2 :: < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_148 > , super :: super :: rules :: r#LeftBrace :: < 'i , 0 > , > > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#ANY , super :: super :: generics :: Skipped < 'i > , 0 >) , > > , super :: super :: generics :: Skipped :: < 'i > , true , Span , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessageText<'i, INHERITED> {}
         :: pest_typed :: rule ! (r#diagMessageInner , "Corresponds to expression: `(diagMessageArg | diagMessageText)*`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessageInner , super :: super :: generics :: Rep :: < 'i , 0 , super :: super :: generics :: Choice2 :: < super :: super :: rules :: r#diagMessageArg :: < 'i , 0 > , super :: super :: rules :: r#diagMessageText :: < 'i , 0 > , > > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessageInner<'i, INHERITED> {
@@ -10276,7 +10297,7 @@ pub mod rules_impl {
                 }
             }
         }
-        :: pest_typed :: rule ! (r#diagMessage , "Corresponds to expression: `(\"\\\"\" ~ diagMessageInner ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessage , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_148 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagMessageInner :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_149 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
+        :: pest_typed :: rule ! (r#diagMessage , "Corresponds to expression: `(\"\\\"\" ~ diagMessageInner ~ \"\\\"\")`. Atomic rule." "" , super :: super :: Rule , super :: super :: Rule :: r#diagMessage , super :: super :: generics :: Seq3 :: < (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_149 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: rules :: r#diagMessageInner :: < 'i , 0 > , super :: super :: generics :: Skipped < 'i > , 0 >) , (:: pest_typed :: predefined_node :: Skipped < super :: super :: generics :: Str :: < super :: super :: constant_wrappers :: r#w_150 > , super :: super :: generics :: Skipped < 'i > , 0 >) , > , super :: super :: generics :: Skipped :: < 'i > , true , Both , true);
         impl<'i, const INHERITED: ::core::primitive::usize> r#diagMessage<'i, INHERITED> {
             #[doc = "A helper function to access [`diagMessageInner`]."]
             #[allow(non_snake_case)]

--- a/crates/rpl_parser/tests/item_patterns.rs
+++ b/crates/rpl_parser/tests/item_patterns.rs
@@ -210,6 +210,37 @@ patt {
 }
 
 #[test]
+fn parses_access_metavariable_type() {
+    let main = parse(
+        r#"
+pattern access-witness
+patt {
+    p[$Access: access] = {
+        struct $Wrapper<..> { .. }
+    } where {
+        true()
+    }
+}
+"#,
+    );
+    let access_ty = main
+        .RPLPattern()
+        .Block()
+        .into_iter()
+        .find_map(|block| block.pattBlock())
+        .expect("patt block")
+        .RPLPatternItem()[0]
+        .MetaVariableDeclList()
+        .expect("meta variable declarations")
+        .MetaVariableDeclsSeparatedByComma()
+        .expect("non-empty meta variable declarations")
+        .MetaVariableDecl()
+        .0
+        .MetaVariableType();
+    assert!(access_ty.kw_access().is_some());
+}
+
+#[test]
 fn bundle_guard_is_unambiguous_and_cannot_be_repeated() {
     let result = parse_main(
         r#"

--- a/crates/rpl_parser/tests/item_patterns.rs
+++ b/crates/rpl_parser/tests/item_patterns.rs
@@ -1,0 +1,247 @@
+#![feature(rustc_private)]
+
+use std::path::Path;
+
+use rpl_parser::{pairs, parse_main};
+
+const ITEM_PATTERN: &str = r#"
+pattern send-variance
+
+patt {
+    send_variance[
+        $Wrapper: adt,
+        $Parameter: type,
+        $MappedType: type,
+    ] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Send for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        true()
+    }
+}
+"#;
+
+fn parse(source: &str) -> pairs::main<'_> {
+    parse_main(source, Path::new("/synthetic/item-pattern.rpl")).expect("item pattern should parse")
+}
+
+#[test]
+fn parses_non_exhaustive_struct_and_bound_impl() {
+    let main = parse(ITEM_PATTERN);
+    let pattern = main.RPLPattern();
+    let patt = pattern
+        .Block()
+        .into_iter()
+        .find_map(|block| block.pattBlock())
+        .expect("patt block");
+    let item = patt.RPLPatternItem().into_iter().next().expect("pattern item");
+
+    let meta_decls = item.MetaVariableDeclList().expect("meta variable declarations");
+    let adt_decl = meta_decls
+        .MetaVariableDeclsSeparatedByComma()
+        .expect("non-empty meta variable declarations")
+        .MetaVariableDecl()
+        .0
+        .MetaVariableType();
+    assert!(adt_decl.kw_adt().is_some());
+    let bundle = item
+        .RustItemsOrPatternOperation()
+        .RustItemsWithConstraint()
+        .expect("item bundle");
+    assert!(
+        bundle.WhereBlock().is_some(),
+        "bundle-level predicates should be retained"
+    );
+    let items = bundle.RustItemWithConstraint();
+    assert_eq!(items.len(), 2);
+
+    let struct_pattern = items[0].RustItem().Struct().expect("struct pattern");
+    assert_eq!(struct_pattern.MetaVariable().span.as_str(), "$Wrapper");
+    assert!(struct_pattern.ItemGenericWildcard().is_some());
+    assert!(
+        struct_pattern
+            .StructFields()
+            .expect("struct fields")
+            .NonExhaustiveFields()
+            .is_some()
+    );
+
+    let impl_pattern = items[1].RustItem().Impl().expect("impl pattern");
+    assert_eq!(
+        impl_pattern
+            .ItemBinding()
+            .expect("impl binding")
+            .MetaVariable()
+            .span
+            .as_str(),
+        "$marker"
+    );
+    assert!(impl_pattern.kw_unsafe().is_some());
+    assert!(impl_pattern.ItemGenericWildcard().is_some());
+    assert_eq!(
+        impl_pattern.ImplKind().expect("trait impl").Path().span.as_str().trim(),
+        "Send"
+    );
+    let self_ty = impl_pattern
+        .ImplSelfType()
+        .ItemAdtType()
+        .expect("non-exhaustive ADT self type");
+    assert_eq!(self_ty.MetaVariable().span.as_str(), "$Wrapper");
+    let _ = self_ty.ItemGenericWildcard();
+    assert!(impl_pattern.ImplWhereClause().is_some());
+}
+
+#[test]
+fn preserves_legacy_struct_and_impl_syntax() {
+    let main = parse(
+        r#"
+pattern legacy-items
+patt {
+    p = {
+        struct $Wrapper {}
+        unsafe impl Send for $Wrapper {}
+    }
+}
+"#,
+    );
+    let item = main
+        .RPLPattern()
+        .Block()
+        .into_iter()
+        .find_map(|block| block.pattBlock())
+        .expect("patt block")
+        .RPLPatternItem()[0]
+        .RustItemsOrPatternOperation()
+        .RustItemsWithConstraint()
+        .expect("item bundle")
+        .RustItemWithConstraint()[1]
+        .RustItem()
+        .Impl()
+        .expect("legacy impl");
+    assert!(
+        item.ImplSelfType().Type().is_some(),
+        "legacy self types should use the ordinary Type arm"
+    );
+}
+
+#[test]
+fn item_wildcard_does_not_leak_into_function_types() {
+    let result = parse_main(
+        r#"
+pattern misplaced-item-wildcard
+patt {
+    p = fn _ ($value: Vec<..>) {}
+}
+"#,
+        Path::new("/synthetic/misplaced-item-wildcard.rpl"),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn impl_where_wildcard_requires_dotdot() {
+    let result = parse_main(
+        r#"
+pattern malformed-impl-where
+patt {
+    p = {
+        struct $Wrapper<..> { .. }
+        $marker: unsafe impl<..> Send for $Wrapper<..> where {} {}
+    }
+}
+"#,
+        Path::new("/synthetic/malformed-impl-where.rpl"),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn parses_named_fields_before_struct_rest() {
+    let main = parse(
+        r#"
+pattern named-field-rest
+patt {
+    p[$Wrapper: adt, $T: type] = {
+        struct $Wrapper<..> {
+            $field: $T,
+            ..
+        }
+    }
+}
+"#,
+    );
+    let fields = main
+        .RPLPattern()
+        .Block()
+        .into_iter()
+        .find_map(|block| block.pattBlock())
+        .expect("patt block")
+        .RPLPatternItem()[0]
+        .RustItemsOrPatternOperation()
+        .RustItemsWithConstraint()
+        .expect("item bundle")
+        .RustItemWithConstraint()[0]
+        .RustItem()
+        .Struct()
+        .expect("struct")
+        .StructFields()
+        .expect("fields")
+        .NonExhaustiveFields()
+        .expect("field rest");
+    assert_eq!(fields.Field().len(), 1);
+}
+
+#[test]
+fn adt_remains_an_ordinary_identifier_outside_meta_variable_types() {
+    parse(
+        r#"
+pattern contextual-adt
+patt {
+    p = fn adt (..) {}
+}
+"#,
+    );
+}
+
+#[test]
+fn bundle_guard_is_unambiguous_and_cannot_be_repeated() {
+    let result = parse_main(
+        r#"
+pattern duplicate-bundle-guard
+patt {
+    p = {
+        struct $Wrapper<..> { .. }
+    } where {
+        true()
+    } where {
+        true()
+    }
+}
+"#,
+        Path::new("/synthetic/duplicate-bundle-guard.rpl"),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn negative_impl_patterns_are_not_accepted_yet() {
+    let result = parse_main(
+        r#"
+pattern negative-impl
+patt {
+    p = {
+        struct $Wrapper<..> { .. }
+        unsafe impl<..> !Send for $Wrapper<..> {}
+    }
+}
+"#,
+        Path::new("/synthetic/negative-impl.rpl"),
+    );
+    assert!(result.is_err());
+}

--- a/crates/rpl_resolve/src/lib.rs
+++ b/crates/rpl_resolve/src/lib.rs
@@ -259,8 +259,6 @@ fn non_local_item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol)
 
 // #[instrument(level = "trace", skip(tcx), ret)]
 fn local_item_children_by_name(tcx: TyCtxt<'_>, local_id: LocalDefId, name: Symbol) -> Vec<Res> {
-    let hir = tcx.hir();
-
     let root_mod;
     let item_kind = match tcx.hir_node_by_def_id(local_id) {
         Node::Crate(r#mod) => {
@@ -287,18 +285,11 @@ fn local_item_children_by_name(tcx: TyCtxt<'_>, local_id: LocalDefId, name: Symb
     };
 
     match item_kind {
-        ItemKind::Mod(r#mod) => r#mod
-            .item_ids
+        ItemKind::Mod(_) => tcx
+            .module_children_local(local_id)
             .iter()
-            .filter_map(|&item_id| {
-                let item = hir.item(item_id);
-                match item.kind {
-                    ItemKind::ForeignMod { abi: _, items } => {
-                        items.iter().find_map(|item| res(item.ident, item.id.owner_id))
-                    },
-                    _ => res(item.ident, item_id.owner_id),
-                }
-            })
+            .filter(|child| child.ident.name == name)
+            .map(|child| child.res.expect_non_local())
             .collect(),
         ItemKind::Impl(r#impl) => r#impl
             .items

--- a/tests/ui/item_patterns/custom_marker_guard.rs
+++ b/tests/ui/item_patterns/custom_marker_guard.rs
@@ -1,0 +1,18 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/custom_marker_guard.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+mod fake {
+    pub unsafe trait Marker {}
+}
+
+mod api {
+    pub use crate::fake::Marker;
+}
+
+unsafe impl<T> fake::Marker for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/custom_marker_guard.stderr
+++ b/tests/ui/item_patterns/custom_marker_guard.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/custom_marker_guard.rs:15:1
+   |
+LL | unsafe impl<T> fake::Marker for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "explicit_custom_marker" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/patterns/custom_marker_guard.rpl
+++ b/tests/ui/item_patterns/patterns/custom_marker_guard.rpl
@@ -1,0 +1,18 @@
+pattern explicit-custom-marker-impl
+
+patt {
+    use $crate::api::Marker;
+
+    explicit_custom_marker[$Wrapper: adt] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Marker for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        true()
+    }
+}

--- a/tests/ui/item_patterns/patterns/false_guard.rpl
+++ b/tests/ui/item_patterns/patterns/false_guard.rpl
@@ -1,0 +1,18 @@
+pattern explicit-send-impl
+
+patt {
+    use core::marker::Send;
+
+    explicit_send[$Wrapper: adt] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Send for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        false()
+    }
+}

--- a/tests/ui/item_patterns/patterns/send_variance.rpl
+++ b/tests/ui/item_patterns/patterns/send_variance.rpl
@@ -1,0 +1,26 @@
+pattern send-variance
+
+patt {
+    use core::marker::Send;
+
+    send_variance[
+        $Wrapper: adt,
+        $Parameter: type,
+        $MappedType: type,
+    ] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Send for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        has_type_parameters($Wrapper)
+        && type_parameter_of($Parameter, $Wrapper)
+        && type_parameter_maps_to($Parameter, $MappedType, $marker)
+        && owns_type($Wrapper, $Parameter)
+        && !is_send_in($MappedType, $marker)
+    }
+}

--- a/tests/ui/item_patterns/patterns/sync_guard.rpl
+++ b/tests/ui/item_patterns/patterns/sync_guard.rpl
@@ -1,0 +1,18 @@
+pattern explicit-sync-impl
+
+patt {
+    use core::marker::Sync;
+
+    explicit_sync[$Wrapper: adt] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Sync for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        true()
+    }
+}

--- a/tests/ui/item_patterns/patterns/sync_variance.rpl
+++ b/tests/ui/item_patterns/patterns/sync_variance.rpl
@@ -1,0 +1,61 @@
+pattern sync-variance
+
+patt {
+    use core::marker::Sync;
+
+    sync_requires_send[
+        $Wrapper: adt,
+        $Parameter: type,
+        $MappedType: type,
+        $Resource: type,
+    ] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Sync for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        has_type_parameters($Wrapper)
+        && type_parameter_of($Parameter, $Wrapper)
+        && type_parameter_maps_to($Parameter, $MappedType, $marker)
+        && resource_exclusively_accessible_from_shared_ref_in(
+            $Resource,
+            $Wrapper,
+            $Parameter,
+            $MappedType,
+            $marker,
+        )
+        && !is_send_in($Resource, $marker)
+    }
+
+    sync_requires_sync[
+        $Wrapper: adt,
+        $Parameter: type,
+        $MappedType: type,
+        $Resource: type,
+    ] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Sync for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        has_type_parameters($Wrapper)
+        && type_parameter_of($Parameter, $Wrapper)
+        && type_parameter_maps_to($Parameter, $MappedType, $marker)
+        && resource_concurrently_accessible_from_shared_ref_in(
+            $Resource,
+            $Wrapper,
+            $Parameter,
+            $MappedType,
+            $marker,
+        )
+        && !is_sync_in($Resource, $marker)
+    }
+}

--- a/tests/ui/item_patterns/patterns/sync_variance.rpl
+++ b/tests/ui/item_patterns/patterns/sync_variance.rpl
@@ -7,6 +7,7 @@ patt {
         $Wrapper: adt,
         $Parameter: type,
         $MappedType: type,
+        $Access: access,
         $Resource: type,
     ] = {
         struct $Wrapper<..> {
@@ -22,19 +23,21 @@ patt {
         && type_parameter_of($Parameter, $Wrapper)
         && type_parameter_maps_to($Parameter, $MappedType, $marker)
         && resource_exclusively_accessible_from_shared_ref_in(
+            $Access,
             $Resource,
             $Wrapper,
             $Parameter,
             $MappedType,
             $marker,
         )
-        && !is_send_in($Resource, $marker)
+        && !is_send_for_access_in($Resource, $Access, $marker)
     }
 
     sync_requires_sync[
         $Wrapper: adt,
         $Parameter: type,
         $MappedType: type,
+        $Access: access,
         $Resource: type,
     ] = {
         struct $Wrapper<..> {
@@ -50,12 +53,13 @@ patt {
         && type_parameter_of($Parameter, $Wrapper)
         && type_parameter_maps_to($Parameter, $MappedType, $marker)
         && resource_concurrently_accessible_from_shared_ref_in(
+            $Access,
             $Resource,
             $Wrapper,
             $Parameter,
             $MappedType,
             $marker,
         )
-        && !is_sync_in($Resource, $marker)
+        && !is_sync_for_access_in($Resource, $Access, $marker)
     }
 }

--- a/tests/ui/item_patterns/patterns/true_guard.rpl
+++ b/tests/ui/item_patterns/patterns/true_guard.rpl
@@ -1,0 +1,18 @@
+pattern explicit-send-impl
+
+patt {
+    use core::marker::Send;
+
+    explicit_send[$Wrapper: adt] = {
+        struct $Wrapper<..> {
+            ..
+        }
+
+        $marker:
+        unsafe impl<..> Send for $Wrapper<..>
+        where ..
+        {}
+    } where {
+        true()
+    }
+}

--- a/tests/ui/item_patterns/rudra_sync/README.md
+++ b/tests/ui/item_patterns/rudra_sync/README.md
@@ -1,13 +1,20 @@
-# Rudra Sync variance fixtures
+# Rudra Send/Sync variance fixtures
 
-These UI tests adapt every `Sync`-bearing fixture from Rudra commit
-`e12e6d3b370efaf19479815f82aa935ead54bae9` under `tests/send_sync/`.
+These UI tests adapt all 12 fixtures from Rudra commit
+`e12e6d3b370efaf19479815f82aa935ead54bae9` under `tests/send_sync/`. Ten contain
+an unsafe `Sync` impl and use `sync_variance.rpl`; the Send-only
+`okay_ptr_like` and `wild_send` cases use `send_variance.rpl`.
 
 RPL intentionally does not preserve Rudra's naive missing-`Sync` reports. The
 current resource-access backend reports `wild_channel`, whose safe `&self` API
 returns `&Q`, and passes the no-API, phantom-only, and acknowledged false-positive
 fixtures. The focused `sync_variance_*` tests cover the independent `Send` and
 `Sync` access requirements that are absent from Rudra's pinned corpus.
+
+RPL also intentionally reports both impls in `okay_ptr_like`: its wrappers own
+`P`, and `P: Sync` does not imply `P: Send`. Rudra classifies that fixture as
+okay because its pointer-like heuristic accepts the weaker bound; this is a
+known semantic difference rather than a missing corpus case.
 
 The pattern surface correlates each resource and trait-support query with an
 explicit access witness. This preserves method and impl bounds and leaves room

--- a/tests/ui/item_patterns/rudra_sync/README.md
+++ b/tests/ui/item_patterns/rudra_sync/README.md
@@ -1,0 +1,10 @@
+# Rudra Sync variance fixtures
+
+These UI tests adapt every `Sync`-bearing fixture from Rudra commit
+`e12e6d3b370efaf19479815f82aa935ead54bae9` under `tests/send_sync/`.
+
+RPL intentionally does not preserve Rudra's naive missing-`Sync` reports. The
+current resource-access backend reports `wild_channel`, whose safe `&self` API
+returns `&Q`, and passes the no-API, phantom-only, and acknowledged false-positive
+fixtures. The focused `sync_variance_*` tests cover the independent `Send` and
+`Sync` access requirements that are absent from Rudra's pinned corpus.

--- a/tests/ui/item_patterns/rudra_sync/README.md
+++ b/tests/ui/item_patterns/rudra_sync/README.md
@@ -8,3 +8,10 @@ current resource-access backend reports `wild_channel`, whose safe `&self` API
 returns `&Q`, and passes the no-API, phantom-only, and acknowledged false-positive
 fixtures. The focused `sync_variance_*` tests cover the independent `Send` and
 `Sync` access requirements that are absent from Rudra's pinned corpus.
+
+The pattern surface correlates each resource and trait-support query with an
+explicit access witness. This preserves method and impl bounds and leaves room
+for an exact evaluator. The first evaluator is deliberately signature-based: it
+recognizes direct safe `&self` methods and can still miss body-mediated, trait,
+guard, alias, and specialized access, or over-report by-value signatures whose
+bodies never transfer the value across threads.

--- a/tests/ui/item_patterns/rudra_sync/no_generic.rs
+++ b/tests/ui/item_patterns/rudra_sync/no_generic.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/no_generic.rs` fixture.
+struct Atom(usize);
+
+unsafe impl Sync for Atom {}
+unsafe impl Send for Atom {}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/okay_channel.rs
+++ b/tests/ui/item_patterns/rudra_sync/okay_channel.rs
@@ -1,0 +1,19 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/okay_channel.rs` known-FP fixture.
+struct Channel<P, Q>(P, Q);
+
+unsafe impl<P: Send, Q: Send> Sync for Channel<P, Q> {}
+
+impl<P, Q> Channel<P, Q> {
+    fn send_p<M>(&self, _message: M)
+    where
+        M: Into<P>,
+    {
+    }
+
+    fn send_q(&self, _message: Box<Q>) {}
+}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/okay_imm.rs
+++ b/tests/ui/item_patterns/rudra_sync/okay_imm.rs
@@ -1,0 +1,9 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/okay_imm.rs` fixture.
+struct Atom<P>(P);
+
+unsafe impl<P: Ord + Sync> Sync for Atom<P> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/okay_phantom.rs
+++ b/tests/ui/item_patterns/rudra_sync/okay_phantom.rs
@@ -1,0 +1,17 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/okay_phantom.rs` fixture. Rudra
+// reports this at its naive tier; RPL finds no resource accessible through `&Atom1`.
+use std::marker::PhantomData;
+
+struct Atom1<'a, P, Q, R> {
+    _marker0: PhantomData<P>,
+    _marker1: PhantomData<Option<*mut P>>,
+    _marker2: PhantomData<Box<(&'a mut Q, Box<Result<R, i32>>)>>,
+}
+
+unsafe impl<'a, A: Send, B, C> Send for Atom1<'a, A, B, C> {}
+unsafe impl<'a, A: Sync, B, C> Sync for Atom1<'a, A, B, C> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/okay_ptr_like.rs
+++ b/tests/ui/item_patterns/rudra_sync/okay_ptr_like.rs
@@ -1,0 +1,14 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+
+// Rudra accepts `P: Sync` as a pointer-like exception. These wrappers own `P`,
+// so RPL requires the stronger `P: Send` bound.
+
+struct Atom1<P>(P);
+unsafe impl<P: Sync> Send for Atom1<P> {}
+//~^ ERROR: A pattern instance found in this span
+
+struct Atom2<P>(P);
+unsafe impl<P> Send for Atom2<P> where P: Sync {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/okay_ptr_like.stderr
+++ b/tests/ui/item_patterns/rudra_sync/okay_ptr_like.stderr
@@ -1,0 +1,21 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/rudra_sync/okay_ptr_like.rs:7:1
+   |
+LL | unsafe impl<P: Sync> Send for Atom1<P> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "send_variance" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/rudra_sync/okay_ptr_like.rs:11:1
+   |
+LL | unsafe impl<P> Send for Atom2<P> where P: Sync {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "send_variance" in the RPL pattern file.
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/item_patterns/rudra_sync/okay_transitive.rs
+++ b/tests/ui/item_patterns/rudra_sync/okay_transitive.rs
@@ -1,0 +1,13 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/okay_transitive.rs` fixture.
+trait Foo: Sync {}
+
+struct Atom0<P>(P);
+unsafe impl<P: Eq + Foo> Sync for Atom0<P> {}
+
+struct Atom1<P>(P);
+unsafe impl<P: Eq> Send for Atom1<P> where P: Foo {}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/okay_where.rs
+++ b/tests/ui/item_patterns/rudra_sync/okay_where.rs
@@ -1,0 +1,16 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/okay_where.rs` fixture.
+struct Atom1<P, Q>(P, Q);
+unsafe impl<P, Q> Send for Atom1<P, Q>
+where
+    Q: Send,
+    P: Copy + Send,
+{
+}
+
+struct Atom2<P>(P);
+unsafe impl<P> Sync for Atom2<P> where P: Sync {}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/sync_over_send_fp.rs
+++ b/tests/ui/item_patterns/rudra_sync/sync_over_send_fp.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/sync_over_send_fp.rs` known-FP
+// fixture. With no safe shared-reference API, neither resource relation holds.
+struct Channel<P, Q>(P, Q);
+
+unsafe impl<P: Sync, Q: Send> Sync for Channel<P, Q> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/wild_channel.rs
+++ b/tests/ui/item_patterns/rudra_sync/wild_channel.rs
@@ -1,0 +1,17 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+// Adapted from Rudra's pinned `tests/send_sync/wild_channel.rs` fixture.
+struct Container<P, Q>(P, Q);
+
+unsafe impl<P: Sync, Q: Send> Sync for Container<P, Q> {}
+//~^ ERROR: A pattern instance found in this span
+
+impl<P, Q> Container<P, Q> {
+    fn append_to_queue(&self, _message: Q) {}
+
+    fn peek_queue_end(&self) -> Result<&Q, ()> {
+        Ok(&self.1)
+    }
+}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/wild_channel.stderr
+++ b/tests/ui/item_patterns/rudra_sync/wild_channel.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/rudra_sync/wild_channel.rs:6:1
+   |
+LL | unsafe impl<P: Sync, Q: Send> Sync for Container<P, Q> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_sync" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/rudra_sync/wild_phantom.rs
+++ b/tests/ui/item_patterns/rudra_sync/wild_phantom.rs
@@ -1,0 +1,17 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/wild_phantom.rs` fixture. The
+// first backend deliberately does not infer safe access from inert pointer fields.
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+struct Atom1<'a, T> {
+    ptr: NonNull<T>,
+    _marker: PhantomData<&'a mut T>,
+}
+
+unsafe impl<'a, A> Send for Atom1<'a, A> {}
+unsafe impl<'a, A> Sync for Atom1<'a, A> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/wild_send.rs
+++ b/tests/ui/item_patterns/rudra_sync/wild_send.rs
@@ -1,0 +1,7 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+
+struct Atom<P>(P);
+unsafe impl<P: Ord> Send for Atom<P> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/rudra_sync/wild_send.stderr
+++ b/tests/ui/item_patterns/rudra_sync/wild_send.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/rudra_sync/wild_send.rs:4:1
+   |
+LL | unsafe impl<P: Ord> Send for Atom<P> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "send_variance" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/rudra_sync/wild_sync.rs
+++ b/tests/ui/item_patterns/rudra_sync/wild_sync.rs
@@ -1,0 +1,15 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+// Adapted from Rudra's pinned `tests/send_sync/wild_sync.rs` fixture. Rudra's
+// naive tier reports the missing `Q: Sync`; RPL requires an accessible resource.
+struct Atom<P, Q>(P, Q);
+
+unsafe impl<P: Send, Q> Sync for Atom<P, Q>
+where
+    Q: Copy,
+    P: Sync,
+{
+}
+
+fn main() {}

--- a/tests/ui/item_patterns/send_false_guard.rs
+++ b/tests/ui/item_patterns/send_false_guard.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/false_guard.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    value: T,
+}
+
+unsafe impl<T> Send for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/send_true_guard.rs
+++ b/tests/ui/item_patterns/send_true_guard.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/true_guard.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+unsafe impl<T> Send for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/send_true_guard.stderr
+++ b/tests/ui/item_patterns/send_true_guard.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/send_true_guard.rs:7:1
+   |
+LL | unsafe impl<T> Send for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "explicit_send" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/send_variance_bound.rs
+++ b/tests/ui/item_patterns/send_variance_bound.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    value: T,
+}
+
+unsafe impl<T> Send for Wrapper<T> where T: Send {}
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_mapped_non_send.rs
+++ b/tests/ui/item_patterns/send_variance_mapped_non_send.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+
+struct Wrapper<P> {
+    value: P,
+}
+
+unsafe impl<T> Send for Wrapper<Option<T>> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_mapped_non_send.stderr
+++ b/tests/ui/item_patterns/send_variance_mapped_non_send.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/send_variance_mapped_non_send.rs:7:1
+   |
+LL | unsafe impl<T> Send for Wrapper<Option<T>> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "send_variance" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/send_variance_mapped_send.rs
+++ b/tests/ui/item_patterns/send_variance_mapped_send.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+//@check-pass
+
+struct Wrapper<P> {
+    value: P,
+}
+
+unsafe impl Send for Wrapper<u8> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_mixed_generics.rs
+++ b/tests/ui/item_patterns/send_variance_mixed_generics.rs
@@ -1,0 +1,14 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+
+use std::marker::PhantomData;
+
+struct Wrapper<'a, T, const N: usize> {
+    value: T,
+    lifetime: PhantomData<&'a ()>,
+    bytes: [u8; N],
+}
+
+unsafe impl<'a, T, const N: usize> Send for Wrapper<'a, T, N> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_mixed_generics.stderr
+++ b/tests/ui/item_patterns/send_variance_mixed_generics.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/send_variance_mixed_generics.rs:11:1
+   |
+LL | unsafe impl<'a, T, const N: usize> Send for Wrapper<'a, T, N> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "send_variance" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/send_variance_multiple_parameters.rs
+++ b/tests/ui/item_patterns/send_variance_multiple_parameters.rs
@@ -1,0 +1,11 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+
+struct Wrapper<T, U> {
+    safe: T,
+    risky: U,
+}
+
+unsafe impl<T: Send, U> Send for Wrapper<T, U> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_multiple_parameters.stderr
+++ b/tests/ui/item_patterns/send_variance_multiple_parameters.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/send_variance_multiple_parameters.rs:8:1
+   |
+LL | unsafe impl<T: Send, U> Send for Wrapper<T, U> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "send_variance" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/send_variance_non_generic.rs
+++ b/tests/ui/item_patterns/send_variance_non_generic.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+//@check-pass
+
+struct Wrapper {
+    value: std::rc::Rc<()>,
+}
+
+unsafe impl Send for Wrapper {}
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_phantom.rs
+++ b/tests/ui/item_patterns/send_variance_phantom.rs
@@ -1,0 +1,12 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+//@check-pass
+
+use std::marker::PhantomData;
+
+struct Wrapper<T> {
+    marker: PhantomData<T>,
+}
+
+unsafe impl<T> Send for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_unbounded.rs
+++ b/tests/ui/item_patterns/send_variance_unbounded.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/send_variance.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+unsafe impl<T> Send for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/send_variance_unbounded.stderr
+++ b/tests/ui/item_patterns/send_variance_unbounded.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/send_variance_unbounded.rs:7:1
+   |
+LL | unsafe impl<T> Send for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "send_variance" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/send_wrong_trait.rs
+++ b/tests/ui/item_patterns/send_wrong_trait.rs
@@ -1,0 +1,14 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/true_guard.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    value: T,
+}
+
+mod custom {
+    pub unsafe trait Send {}
+}
+
+unsafe impl<T> custom::Send for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_guard.rs
+++ b/tests/ui/item_patterns/sync_guard.rs
@@ -1,0 +1,10 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_guard.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_guard.stderr
+++ b/tests/ui/item_patterns/sync_guard.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_guard.rs:7:1
+   |
+LL | unsafe impl<T> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "explicit_sync" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/sync_variance_access_correlation.rs
+++ b/tests/ui/item_patterns/sync_variance_access_correlation.rs
@@ -1,0 +1,23 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> {
+    fn guarded(&self) -> &T
+    where
+        T: Sync,
+    {
+        &self.value
+    }
+
+    fn unguarded(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_access_correlation.stderr
+++ b/tests/ui/item_patterns/sync_variance_access_correlation.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_access_correlation.rs:20:1
+   |
+LL | unsafe impl<T> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_sync" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/sync_variance_both_bounds.rs
+++ b/tests/ui/item_patterns/sync_variance_both_bounds.rs
@@ -1,0 +1,23 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+use std::sync::Mutex;
+
+struct Wrapper<T> {
+    shared: T,
+    exclusive: Mutex<T>,
+}
+
+impl<T> Wrapper<T> {
+    fn get(&self) -> &T {
+        &self.shared
+    }
+
+    fn replace(&self, value: T) -> T {
+        std::mem::replace(&mut *self.exclusive.lock().unwrap(), value)
+    }
+}
+
+unsafe impl<T: Send + Sync> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_both_unbounded.rs
+++ b/tests/ui/item_patterns/sync_variance_both_unbounded.rs
@@ -1,0 +1,24 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+use std::sync::Mutex;
+
+struct Wrapper<T> {
+    shared: T,
+    exclusive: Mutex<T>,
+}
+
+impl<T> Wrapper<T> {
+    fn get(&self) -> &T {
+        &self.shared
+    }
+
+    fn replace(&self, value: T) -> T {
+        std::mem::replace(&mut *self.exclusive.lock().unwrap(), value)
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+//~| ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_both_unbounded.stderr
+++ b/tests/ui/item_patterns/sync_variance_both_unbounded.stderr
@@ -1,0 +1,21 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_both_unbounded.rs:20:1
+   |
+LL | unsafe impl<T> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_send" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_both_unbounded.rs:20:1
+   |
+LL | unsafe impl<T> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_sync" in the RPL pattern file.
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/item_patterns/sync_variance_impl_sync_bound.rs
+++ b/tests/ui/item_patterns/sync_variance_impl_sync_bound.rs
@@ -1,0 +1,16 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T: Sync> Wrapper<T> {
+    fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_method_clone_bound.rs
+++ b/tests/ui/item_patterns/sync_variance_method_clone_bound.rs
@@ -1,0 +1,19 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> {
+    fn get(&self) -> &T
+    where
+        T: Clone,
+    {
+        &self.value
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_method_clone_bound.stderr
+++ b/tests/ui/item_patterns/sync_variance_method_clone_bound.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_method_clone_bound.rs:16:1
+   |
+LL | unsafe impl<T> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_sync" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/sync_variance_method_send_bound.rs
+++ b/tests/ui/item_patterns/sync_variance_method_send_bound.rs
@@ -1,0 +1,21 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+use std::sync::Mutex;
+
+struct Wrapper<T> {
+    value: Mutex<T>,
+}
+
+impl<T> Wrapper<T> {
+    fn replace(&self, value: T) -> T
+    where
+        T: Send,
+    {
+        std::mem::replace(&mut *self.value.lock().unwrap(), value)
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_method_sync_bound.rs
+++ b/tests/ui/item_patterns/sync_variance_method_sync_bound.rs
@@ -1,0 +1,19 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> {
+    fn get(&self) -> &T
+    where
+        T: Sync,
+    {
+        &self.value
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_moves_send_bound.rs
+++ b/tests/ui/item_patterns/sync_variance_moves_send_bound.rs
@@ -1,0 +1,18 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+use std::sync::Mutex;
+
+struct Wrapper<T> {
+    value: Mutex<T>,
+}
+
+impl<T> Wrapper<T> {
+    fn replace(&self, value: T) -> T {
+        std::mem::replace(&mut *self.value.lock().unwrap(), value)
+    }
+}
+
+unsafe impl<T: Send> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_moves_sync_only.rs
+++ b/tests/ui/item_patterns/sync_variance_moves_sync_only.rs
@@ -1,0 +1,18 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+use std::sync::Mutex;
+
+struct Wrapper<T> {
+    value: Mutex<T>,
+}
+
+impl<T> Wrapper<T> {
+    fn replace(&self, value: T) -> T {
+        std::mem::replace(&mut *self.value.lock().unwrap(), value)
+    }
+}
+
+unsafe impl<T: Sync> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_moves_sync_only.stderr
+++ b/tests/ui/item_patterns/sync_variance_moves_sync_only.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_moves_sync_only.rs:15:1
+   |
+LL | unsafe impl<T: Sync> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_send" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/sync_variance_moves_unbounded.rs
+++ b/tests/ui/item_patterns/sync_variance_moves_unbounded.rs
@@ -1,0 +1,18 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+use std::sync::Mutex;
+
+struct Wrapper<T> {
+    value: Mutex<T>,
+}
+
+impl<T> Wrapper<T> {
+    fn replace(&self, value: T) -> T {
+        std::mem::replace(&mut *self.value.lock().unwrap(), value)
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_moves_unbounded.stderr
+++ b/tests/ui/item_patterns/sync_variance_moves_unbounded.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_moves_unbounded.rs:15:1
+   |
+LL | unsafe impl<T> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_send" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/sync_variance_phantom_ref.rs
+++ b/tests/ui/item_patterns/sync_variance_phantom_ref.rs
@@ -1,0 +1,18 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+use std::marker::PhantomData;
+
+struct Wrapper<T> {
+    marker: PhantomData<T>,
+}
+
+impl<T> Wrapper<T> {
+    fn marker(&self) -> &PhantomData<T> {
+        &self.marker
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_raw_pointer_ref.rs
+++ b/tests/ui/item_patterns/sync_variance_raw_pointer_ref.rs
@@ -1,0 +1,16 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    pointer: *const T,
+}
+
+impl<T> Wrapper<T> {
+    fn pointer(&self) -> &*const T {
+        &self.pointer
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_shares_send_only.rs
+++ b/tests/ui/item_patterns/sync_variance_shares_send_only.rs
@@ -1,0 +1,16 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> {
+    fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T: Send> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_shares_send_only.stderr
+++ b/tests/ui/item_patterns/sync_variance_shares_send_only.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_shares_send_only.rs:13:1
+   |
+LL | unsafe impl<T: Send> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_sync" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/sync_variance_shares_sync_bound.rs
+++ b/tests/ui/item_patterns/sync_variance_shares_sync_bound.rs
@@ -1,0 +1,16 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> {
+    fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T: Sync> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_shares_unbounded.rs
+++ b/tests/ui/item_patterns/sync_variance_shares_unbounded.rs
@@ -1,0 +1,16 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> {
+    fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+//~^ ERROR: A pattern instance found in this span
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_shares_unbounded.stderr
+++ b/tests/ui/item_patterns/sync_variance_shares_unbounded.stderr
@@ -1,0 +1,12 @@
+error: A pattern instance found in this span
+  --> tests/ui/item_patterns/sync_variance_shares_unbounded.rs:13:1
+   |
+LL | unsafe impl<T> Sync for Wrapper<T> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: This is a fallback diagnostic message.
+   = note: You are seeing this because there is no corresponding diagnostic item for pattern "sync_requires_sync" in the RPL pattern file.
+   = note: `#[deny(rpl::missing_diagnostic)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/item_patterns/sync_variance_supertrait_bound.rs
+++ b/tests/ui/item_patterns/sync_variance_supertrait_bound.rs
@@ -1,0 +1,20 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+trait SafeToShare: Sync {}
+
+impl<T: Sync> SafeToShare for T {}
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T: SafeToShare> Wrapper<T> {
+    fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+
+fn main() {}

--- a/tests/ui/item_patterns/sync_variance_unsafe_method.rs
+++ b/tests/ui/item_patterns/sync_variance_unsafe_method.rs
@@ -1,0 +1,16 @@
+//@rustc-env: RPL_PATS=tests/ui/item_patterns/patterns/sync_variance.rpl
+//@check-pass
+
+struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> {
+    unsafe fn get_unchecked(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T> Sync for Wrapper<T> {}
+
+fn main() {}


### PR DESCRIPTION
## Summary

Add a framework-level foundation for Rudra-inspired Send/Sync bug detection using composable predicates over Rust program properties, rather than a dedicated Rudra checker.

- Parse, validate, lower, and document struct/impl item patterns, ADT/access metavariables, wildcard generics/fields/where clauses, impl bindings, and bundle-level predicate guards.
- Match explicit positive unsafe trait impls at HIR/type level using resolved trait identities and explicit paths/imports, including custom traits and local reexports.
- Evaluate Send ownership/bound predicates and Sync resource-access predicates as correlated relational rows. Preserve the access witness so a bound on one method cannot justify a different method.
- Keep upstream's function/ADT MatchSession path alongside the item matcher. Register upstream's `has_attr` predicate for the stricter where-clause validation and cover the integration with a regression test.
- Add focused parser, metadata, documentation, and UI coverage, including all 12 pinned Rudra Send/Sync fixtures.

The example detection patterns currently live in UI fixtures; this does not enable new default built-in lints. The work is split into eleven commits and rebased onto master at `6fb8514`.

## Example enabled by this change

```text
pattern send-variance

patt {
    use core::marker::Send;

    send_variance[
        $Wrapper: adt,
        $Parameter: type,
        $MappedType: type,
    ] = {
        struct $Wrapper<..> { .. }

        $marker:
        unsafe impl<..> Send for $Wrapper<..>
        where ..
        {}
    } where {
        has_type_parameters($Wrapper)
        && type_parameter_of($Parameter, $Wrapper)
        && type_parameter_maps_to($Parameter, $MappedType, $marker)
        && owns_type($Wrapper, $Parameter)
        && !is_send_in($MappedType, $marker)
    }
}
```

The Sync examples separately check exclusive resource access requiring Send and concurrent resource access requiring Sync, correlating each trait query with its own access context.

## Current precision / draft scope

The predicate evaluators are initial approximations, not a sound or complete Send/Sync analysis:

- Ownership follows structural by-value fields, with special handling for Box, PhantomData, pointers/references, and unresolved aliases.
- Shared-reference access is signature-based and recognizes direct safe inherent methods. Body-mediated, trait, guard, alias, and specialized access require further work; by-value signatures can over-report when the body never transfers the value.
- Relational evaluation carries unknown/incomplete results, but the current trait-proof backends still map failed rustc proofs to false. Failure to prove a bound is not proof of a concrete non-Send/Sync counterexample.
- Access-specific trait checks currently accept a proof from either the marker-impl environment or the correlated method environment; a fully combined instantiated environment is future work.

Rudra fixture expectations intentionally reflect these predicate semantics, not identical diagnostic output from Rudra.

## Validation

On macOS/aarch64 after the rebase (subsequent changes only corrected commit attribution):

- UI tests with embedded and external patterns: **261 passed, 19 ignored**, including all **42 Send/Sync cases**.
- Workspace unit/integration tests and the new `has_attr` regression passed.
- `cargo clippy --workspace -- -D warnings` and Clippy for the new regression test passed.
- `cargo fmt --all -- --check`, `python3 scripts/check_rpl_patterns.py`, and `git diff --check` passed.
- Documentation test invocation completed; the four available doctests are ignored.

**Outstanding smoke-test caveat:** lintcheck's third-party `cc 1.0.67` run was stopped after 5m38s at approximately 100% CPU. A process sample located the time in unchanged upstream MIR interblock dependency-graph construction. That smoke check remains unverified; lintcheck's harness returns success even when a checked crate fails, so its exit status alone is not treated as a clean result. Cache-related failures were also observed during the initial smoke runs.

---

Earlier implementation commits are attributed to GPT-5.6; the rebase compatibility fix is attributed to GPT-6.

Generated by Codex (GPT-6) on behalf of @jellllly420
